### PR TITLE
Adds support for ar:// links embedded in content

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ WayFinder (alpha) is a simple, open source, Google Chrome extension that intelli
 - Developers who want to integrate ar:// protocol.  Wayfinder shows how the ar:// protocol could be leveraged along with how to discover gateways on the ar.io network.
 
 # MVP Features
-- ar:// routing: Checks if the user enters an ar:// url, including ArNS names and Arweave Transaction IDs and routes to an available gateway.
+- ar:// routing in the browser search bar and within pages that use ar:// hyperlinks.
+- Automatically routes ArNS names and Arweave Transaction IDs to an available gateway.
 - Algorithmic Gateway Selection: Utilizes basic algorithm to route users through the most optimal gateway.
 - Gateway Discovery: Synchronizes the AR.IO Gateway Address registry providing up to date gateway selection.
 - Static Gateway Configuration: Allows advanced users to pin their sessions to a specific gateway.

--- a/content.js
+++ b/content.js
@@ -1,0 +1,18 @@
+// checks for <a href="ar://..."> pattern
+document.body.addEventListener('click', function(e) {
+    if (e.target.tagName === 'A' && e.target.href.startsWith('ar://')) {
+        e.preventDefault(); 
+        
+        const arUrl = e.target.href;
+        
+        // Determine the target behavior
+        let targetBehavior = e.target.getAttribute('target');
+
+        // Communicate with background script to handle routing
+        chrome.runtime.sendMessage({ 
+            type: 'arUrlClicked', 
+            arUrl,
+            target: targetBehavior 
+        });
+    }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "AR.IO WayFinder",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "description": "WayFinder (Alpha) streamlines access to the Permaweb through the AR.IO Network and Arweave Name System.",
     "permissions": ["storage", "webNavigation", "webRequest"],
     "background": {
@@ -11,6 +11,12 @@
     "action": {
       "default_popup": "popup.html"
     },
+    "content_scripts": [
+      {
+          "matches": ["<all_urls>"],
+          "js": ["content.js"]
+      }
+    ],
     "content_security_policy": {
       "extension_pages": "script-src 'self'; object-src 'self';"
     },


### PR DESCRIPTION
Pages, sites and apps can embed ar:// urls as hyperlinks which will now be identified by Wayfinder and routed to an online ar.io gateway.