### PR TITLE
Add path/subdomain options for gateway checks

### DIFF
--- a/packages/core/src/gateways/network.ts
+++ b/packages/core/src/gateways/network.ts
@@ -50,7 +50,7 @@ export class NetworkGatewaysProvider implements GatewaysProvider {
     this.logger = logger;
   }
 
-  async getGateways(): Promise<URL[]> {
+  async getGateways(_params?: { path?: string; subdomain?: string }): Promise<URL[]> {
     let cursor: string | undefined;
     let attempts = 0;
     const gateways: any[] = [];

--- a/packages/core/src/gateways/simple-cache.ts
+++ b/packages/core/src/gateways/simple-cache.ts
@@ -57,7 +57,7 @@ export class SimpleCacheGatewaysProvider implements GatewaysProvider {
     this.logger = logger;
   }
 
-  async getGateways(): Promise<URL[]> {
+  async getGateways(params?: { path?: string; subdomain?: string }): Promise<URL[]> {
     const now = Date.now();
     if (
       this.gatewaysCache.length === 0 ||
@@ -70,7 +70,7 @@ export class SimpleCacheGatewaysProvider implements GatewaysProvider {
         });
 
         // preserve the cache if the fetch fails
-        const allGateways = await this.gatewaysProvider.getGateways();
+        const allGateways = await this.gatewaysProvider.getGateways(params);
         this.gatewaysCache = allGateways;
         this.lastUpdated = now;
 

--- a/packages/core/src/gateways/static.ts
+++ b/packages/core/src/gateways/static.ts
@@ -22,7 +22,7 @@ export class StaticGatewaysProvider implements GatewaysProvider {
     this.gateways = gateways.map((g) => new URL(g));
   }
 
-  async getGateways(): Promise<URL[]> {
+  async getGateways(_params?: { path?: string; subdomain?: string }): Promise<URL[]> {
     return this.gateways;
   }
 }

--- a/packages/core/src/routing/random.ts
+++ b/packages/core/src/routing/random.ts
@@ -18,7 +18,13 @@ import { RoutingStrategy } from '../../types/wayfinder.js';
 import { randomInt } from '../utils/random.js';
 
 export class RandomRoutingStrategy implements RoutingStrategy {
-  async selectGateway({ gateways }: { gateways: URL[] }): Promise<URL> {
+  async selectGateway({
+    gateways,
+  }: {
+    gateways: URL[];
+    path?: string;
+    subdomain?: string;
+  }): Promise<URL> {
     if (gateways.length === 0) {
       throw new Error('No gateways available');
     }

--- a/packages/core/src/routing/round-robin.ts
+++ b/packages/core/src/routing/round-robin.ts
@@ -57,6 +57,8 @@ export class RoundRobinRoutingStrategy implements RoutingStrategy {
     gateways = [],
   }: {
     gateways?: URL[];
+    path?: string;
+    subdomain?: string;
   } = {}): Promise<URL> {
     if (gateways.length > 0) {
       this.logger.warn(

--- a/packages/core/src/routing/static.ts
+++ b/packages/core/src/routing/static.ts
@@ -56,6 +56,8 @@ export class StaticRoutingStrategy implements RoutingStrategy {
     gateways = [],
   }: {
     gateways?: URL[];
+    path?: string;
+    subdomain?: string;
   } = {}): Promise<URL> {
     if (gateways.length > 0) {
       this.logger.warn(

--- a/packages/core/types/wayfinder.d.ts
+++ b/packages/core/types/wayfinder.d.ts
@@ -19,11 +19,15 @@
 export type DataStream = ReadableStream<Uint8Array> | AsyncIterable<Uint8Array>;
 
 export interface GatewaysProvider {
-  getGateways(): Promise<URL[]>;
+  getGateways(params?: { path?: string; subdomain?: string }): Promise<URL[]>;
 }
 
 export interface RoutingStrategy {
-  selectGateway(params: { gateways: URL[] }): Promise<URL>;
+  selectGateway(params: {
+    gateways: URL[];
+    path?: string;
+    subdomain?: string;
+  }): Promise<URL>;
 }
 
 export interface VerificationStrategy {


### PR DESCRIPTION
## Summary
- extend `GatewaysProvider` and `RoutingStrategy` interfaces to accept optional `path` and `subdomain`
- support the new options in gateway providers
- include these options when performing HEAD checks in ping and fallback routers
- simplify `FastestPingRoutingStrategy` so that it uses only the path provided

## Testing
- `node --import=./register.mjs --test packages/core/src/**/*.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_684cfde738a88328a415a0bba13ee62b