### PR TITLE
Fix/arns subdomain routing

### DIFF
--- a/.changeset/ready-shoes-double.md
+++ b/.changeset/ready-shoes-double.md
@@ -1,0 +1,5 @@
+---
+"@ar.io/wayfinder-core": minor
+---
+
+Fixed ArNS subdomain routing to properly handle multi-level gateway domains

--- a/packages/core/src/emitter.ts
+++ b/packages/core/src/emitter.ts
@@ -1,0 +1,74 @@
+/**
+ * WayFinder
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { EventEmitter } from 'eventemitter3';
+import { WayfinderEvent, WayfinderEventArgs } from './types.js';
+
+export class WayfinderEmitter extends EventEmitter<WayfinderEvent> {
+  constructor({
+    verification,
+    routing,
+    parentEmitter,
+  }: WayfinderEventArgs = {}) {
+    super();
+    if (verification) {
+      if (verification.onVerificationSucceeded) {
+        this.on('verification-succeeded', verification.onVerificationSucceeded);
+      }
+      if (verification.onVerificationFailed) {
+        this.on('verification-failed', verification.onVerificationFailed);
+      }
+      if (verification.onVerificationProgress) {
+        this.on('verification-progress', verification.onVerificationProgress);
+      }
+    }
+    if (routing) {
+      if (routing.onRoutingStarted) {
+        this.on('routing-started', routing.onRoutingStarted);
+      }
+      if (routing.onRoutingSkipped) {
+        this.on('routing-skipped', routing.onRoutingSkipped);
+      }
+      if (routing.onRoutingSucceeded) {
+        this.on('routing-succeeded', routing.onRoutingSucceeded);
+      }
+    }
+
+    if (parentEmitter) {
+      this.on('routing-started', (event) => {
+        parentEmitter.emit('routing-started', event);
+      });
+      this.on('routing-skipped', (event) => {
+        parentEmitter.emit('routing-skipped', event);
+      });
+      this.on('routing-succeeded', (event) => {
+        parentEmitter.emit('routing-succeeded', event);
+      });
+      this.on('verification-succeeded', (event) => {
+        parentEmitter.emit('verification-succeeded', event);
+      });
+      this.on('verification-failed', (event) => {
+        parentEmitter.emit('verification-failed', event);
+      });
+      this.on('verification-progress', (event) => {
+        parentEmitter.emit('verification-progress', event);
+      });
+      this.on('verification-skipped', (event) => {
+        parentEmitter.emit('verification-skipped', event);
+      });
+    }
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,6 +36,8 @@ export * from './verification/data-root-verifier.js';
 export * from './verification/hash-verifier.js';
 export * from './verification/signature-verifier.js';
 
+// emitter
+export * from './emitter.js';
+
 // wayfinder
-// TODO: consider exporting just Wayfinder and move all the types to the types folder
 export * from './wayfinder.js';

--- a/packages/core/src/wayfinder.ts
+++ b/packages/core/src/wayfinder.ts
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { EventEmitter } from 'eventemitter3';
 
 import { defaultLogger } from './logger.js';
 
@@ -26,160 +25,97 @@ import type {
   Logger,
   TelemetrySettings,
   VerificationStrategy,
-  WayfinderEvent,
-  WayfinderEventArgs,
   WayfinderFetch,
   WayfinderOptions,
 } from './types.js';
 import { sandboxFromId } from './utils/base64.js';
 import { HashVerificationStrategy } from './verification/hash-verifier.js';
+import { WayfinderEmitter } from './emitter.js';
 
 // known regexes for wayfinder urls
 export const arnsRegex = /^[a-z0-9_-]{1,51}$/;
 export const txIdRegex = /^[A-Za-z0-9_-]{43}$/;
 
 /**
- * Core function that converts a wayfinder url to the proper ar-io gateway URL
- * @param originalUrl - the wayfinder url to resolve
- * @param selectedGateway - the target gateway to resolve the url against
- * @returns the resolved url that can be used to make a request
+ * Extracts subdomain and path information from an ar:// URL for routing purposes
+ * @param arUrl - the ar:// URL to parse
+ * @returns object containing subdomain and path for gateway routing
  */
-export const resolveWayfinderUrl = ({
-  originalUrl,
-  selectedGateway,
-  logger,
-}: {
-  originalUrl: string;
-  selectedGateway: URL;
-  logger?: Logger;
-}): URL => {
-  if (originalUrl.toString().startsWith('ar://')) {
-    logger?.debug(`Applying wayfinder routing protocol to ${originalUrl}`, {
-      originalUrl,
-    });
-    const [, path] = originalUrl.toString().split('ar://');
-
-    // e.g. ar:///info should route to the info endpoint of the target gateway
-    if (path.startsWith('/')) {
-      logger?.debug(`Routing to ${path.slice(1)} on ${selectedGateway}`, {
-        originalUrl,
-        selectedGateway,
-      });
-      return new URL(path.slice(1), selectedGateway);
-    }
-
-    // Split path to get the first part (name/txId) and remaining path components
-    const [firstPart, ...rest] = path.split('/');
-
-    // TODO: this breaks 43 character named arns names - we should check a a local name cache list before resolving raw transaction ids
-    if (txIdRegex.test(firstPart)) {
-      const sandbox = sandboxFromId(firstPart);
-      // For transaction IDs, we use sandbox subdomain routing
-      // This properly handles multi-level domains: sandbox.gateway.example.com
-      const gatewayUrl = new URL(selectedGateway);
-      gatewayUrl.hostname = `${sandbox}.${gatewayUrl.hostname}`;
-      gatewayUrl.pathname = `/${firstPart}${
-        rest.length > 0 ? '/' + rest.join('/') : ''
-      }`;
-
-      logger?.debug(
-        `Routing transaction ${firstPart} to ${gatewayUrl.toString()}`,
-        {
-          originalUrl,
-          selectedGateway,
-          resolvedUrl: gatewayUrl.toString(),
-        },
-      );
-
-      return gatewayUrl;
-    }
-
-    if (arnsRegex.test(firstPart)) {
-      // For ArNS names, prepend the name as a subdomain
-      // This properly handles multi-level domains: arnsname.gateway.example.com
-      const gatewayUrl = new URL(selectedGateway);
-      gatewayUrl.hostname = `${firstPart}.${gatewayUrl.hostname}`;
-      gatewayUrl.pathname = rest.length > 0 ? `/${rest.join('/')}` : '/';
-
-      logger?.debug(
-        `Routing ArNS name ${firstPart} to ${gatewayUrl.toString()}`,
-        {
-          originalUrl,
-          selectedGateway,
-          resolvedUrl: gatewayUrl.toString(),
-        },
-      );
-
-      return gatewayUrl;
-    }
-
-    // TODO: support .eth addresses
-    // TODO: "gasless" routing via DNS TXT records
+export const extractRoutingInfo = (
+  arUrl: string,
+): { subdomain: string; path: string } => {
+  if (!arUrl.startsWith('ar://')) {
+    return { subdomain: '', path: '' };
   }
 
-  logger?.debug('No wayfinder routing protocol applied', {
-    originalUrl,
-  });
+  const [, pathPart] = arUrl.split('ar://');
 
-  // return the original url if it's not a wayfinder url
-  return new URL(originalUrl);
+  // Handle ar:///info style URLs (direct gateway endpoints)
+  if (pathPart.startsWith('/')) {
+    return { subdomain: '', path: pathPart };
+  }
+
+  // Split path to get the first part (name/txId) and remaining path components
+  const [firstPart, ...rest] = pathPart.split('/');
+  const remainingPath = rest.length > 0 ? `/${rest.join('/')}` : '';
+
+  if (txIdRegex.test(firstPart)) {
+    // For transaction IDs, use sandbox subdomain
+    const sandbox = sandboxFromId(firstPart);
+    return {
+      subdomain: sandbox,
+      path: `/${firstPart}${remainingPath}`,
+    };
+  }
+
+  if (arnsRegex.test(firstPart)) {
+    // For ArNS names, use the name as subdomain
+    return {
+      subdomain: firstPart,
+      path: remainingPath || '/',
+    };
+  }
+
+  // Default case - no special routing
+  return { subdomain: '', path: `/${pathPart}` };
 };
 
-export class WayfinderEmitter extends EventEmitter<WayfinderEvent> {
-  constructor({
-    verification,
-    routing,
-    parentEmitter,
-  }: WayfinderEventArgs = {}) {
-    super();
-    if (verification) {
-      if (verification.onVerificationSucceeded) {
-        this.on('verification-succeeded', verification.onVerificationSucceeded);
-      }
-      if (verification.onVerificationFailed) {
-        this.on('verification-failed', verification.onVerificationFailed);
-      }
-      if (verification.onVerificationProgress) {
-        this.on('verification-progress', verification.onVerificationProgress);
-      }
-    }
-    if (routing) {
-      if (routing.onRoutingStarted) {
-        this.on('routing-started', routing.onRoutingStarted);
-      }
-      if (routing.onRoutingSkipped) {
-        this.on('routing-skipped', routing.onRoutingSkipped);
-      }
-      if (routing.onRoutingSucceeded) {
-        this.on('routing-succeeded', routing.onRoutingSucceeded);
-      }
-    }
+/**
+ * Constructs the final gateway URL using the selected gateway and routing information
+ * @param selectedGateway - the selected gateway
+ * @param subdomain - the subdomain to prepend to the gateway
+ * @param path - the path to append to the gateway
+ * @param logger - optional logger for debugging
+ * @returns the constructed URL
+ */
+export const constructGatewayUrl = ({
+  selectedGateway,
+  subdomain,
+  path,
+  logger,
+}: {
+  selectedGateway: URL;
+  subdomain: string;
+  path: string;
+  logger?: Logger;
+}): URL => {
+  const gatewayUrl = new URL(selectedGateway);
 
-    if (parentEmitter) {
-      this.on('routing-started', (event) => {
-        parentEmitter.emit('routing-started', event);
-      });
-      this.on('routing-skipped', (event) => {
-        parentEmitter.emit('routing-skipped', event);
-      });
-      this.on('routing-succeeded', (event) => {
-        parentEmitter.emit('routing-succeeded', event);
-      });
-      this.on('verification-succeeded', (event) => {
-        parentEmitter.emit('verification-succeeded', event);
-      });
-      this.on('verification-failed', (event) => {
-        parentEmitter.emit('verification-failed', event);
-      });
-      this.on('verification-progress', (event) => {
-        parentEmitter.emit('verification-progress', event);
-      });
-      this.on('verification-skipped', (event) => {
-        parentEmitter.emit('verification-skipped', event);
-      });
-    }
+  if (subdomain) {
+    gatewayUrl.hostname = `${subdomain}.${gatewayUrl.hostname}`;
   }
-}
+
+  gatewayUrl.pathname = path;
+
+  logger?.debug(`Constructed gateway URL`, {
+    selectedGateway: selectedGateway.toString(),
+    subdomain,
+    path,
+    resultUrl: gatewayUrl.toString(),
+  });
+
+  return gatewayUrl;
+};
 
 export function tapAndVerifyReadableStream({
   originalStream,
@@ -355,11 +291,14 @@ export const wayfinderFetch = ({
 
     for (let i = 0; i < maxRetries; i++) {
       try {
+        // extract routing information from the ar:// URL
+        const { subdomain, path } = extractRoutingInfo(url);
+
         // select the target gateway
         const selectedGateway = await routingSettings.strategy?.selectGateway({
           gateways: await gatewaysProvider.getGateways(),
-          path: url.split('/').slice(1).join('/'), // everything after the first /
-          subdomain: '',
+          path,
+          subdomain,
         });
 
         if (!selectedGateway) {
@@ -371,10 +310,11 @@ export const wayfinderFetch = ({
           selectedGateway: selectedGateway?.toString(),
         });
 
-        // route the request to the target gateway
-        const redirectUrl = await resolveWayfinderUrl({
-          originalUrl: url.toString(),
+        // construct the final gateway URL
+        const redirectUrl = constructGatewayUrl({
           selectedGateway,
+          subdomain,
+          path,
           logger,
         });
 
@@ -750,15 +690,26 @@ export class Wayfinder {
     });
 
     this.resolveUrl = async ({ originalUrl, logger = this.logger }) => {
+      // extract routing information from the original URL
+      const { subdomain, path } = extractRoutingInfo(originalUrl);
+
+      // if not an ar:// URL, return as-is
+      if (!originalUrl.startsWith('ar://')) {
+        return new URL(originalUrl);
+      }
+
       const selectedGateway = await this.routingSettings.strategy.selectGateway(
         {
           gateways: await this.gatewaysProvider.getGateways(),
+          path,
+          subdomain,
         },
       );
 
-      return resolveWayfinderUrl({
-        originalUrl,
+      return constructGatewayUrl({
         selectedGateway,
+        subdomain,
+        path,
         logger,
       });
     };

--- a/packages/core/src/wayfinder.ts
+++ b/packages/core/src/wayfinder.ts
@@ -14,13 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { EventEmitter } from "eventemitter3";
+import { EventEmitter } from 'eventemitter3';
 
-import { defaultLogger } from "./logger.js";
+import { defaultLogger } from './logger.js';
 
-import { type Tracer, context, trace } from "@opentelemetry/api";
-import { FastestPingRoutingStrategy } from "./routing/ping.js";
-import { initTelemetry, startRequestSpans } from "./telemetry.js";
+import { type Tracer, context, trace } from '@opentelemetry/api';
+import { FastestPingRoutingStrategy } from './routing/ping.js';
+import { initTelemetry, startRequestSpans } from './telemetry.js';
 import type {
   GatewaysProvider,
   Logger,
@@ -30,9 +30,9 @@ import type {
   WayfinderEventArgs,
   WayfinderFetch,
   WayfinderOptions,
-} from "./types.js";
-import { sandboxFromId } from "./utils/base64.js";
-import { HashVerificationStrategy } from "./verification/hash-verifier.js";
+} from './types.js';
+import { sandboxFromId } from './utils/base64.js';
+import { HashVerificationStrategy } from './verification/hash-verifier.js';
 
 // known regexes for wayfinder urls
 export const arnsRegex = /^[a-z0-9_-]{1,51}$/;
@@ -53,14 +53,14 @@ export const resolveWayfinderUrl = ({
   selectedGateway: URL;
   logger?: Logger;
 }): URL => {
-  if (originalUrl.toString().startsWith("ar://")) {
+  if (originalUrl.toString().startsWith('ar://')) {
     logger?.debug(`Applying wayfinder routing protocol to ${originalUrl}`, {
       originalUrl,
     });
-    const [, path] = originalUrl.toString().split("ar://");
+    const [, path] = originalUrl.toString().split('ar://');
 
     // e.g. ar:///info should route to the info endpoint of the target gateway
-    if (path.startsWith("/")) {
+    if (path.startsWith('/')) {
       logger?.debug(`Routing to ${path.slice(1)} on ${selectedGateway}`, {
         originalUrl,
         selectedGateway,
@@ -69,7 +69,7 @@ export const resolveWayfinderUrl = ({
     }
 
     // Split path to get the first part (name/txId) and remaining path components
-    const [firstPart, ...rest] = path.split("/");
+    const [firstPart, ...rest] = path.split('/');
 
     // TODO: this breaks 43 character named arns names - we should check a a local name cache list before resolving raw transaction ids
     if (txIdRegex.test(firstPart)) {
@@ -79,7 +79,7 @@ export const resolveWayfinderUrl = ({
       const gatewayUrl = new URL(selectedGateway);
       gatewayUrl.hostname = `${sandbox}.${gatewayUrl.hostname}`;
       gatewayUrl.pathname = `/${firstPart}${
-        rest.length > 0 ? "/" + rest.join("/") : ""
+        rest.length > 0 ? '/' + rest.join('/') : ''
       }`;
 
       logger?.debug(
@@ -88,7 +88,7 @@ export const resolveWayfinderUrl = ({
           originalUrl,
           selectedGateway,
           resolvedUrl: gatewayUrl.toString(),
-        }
+        },
       );
 
       return gatewayUrl;
@@ -99,7 +99,7 @@ export const resolveWayfinderUrl = ({
       // This properly handles multi-level domains: arnsname.gateway.example.com
       const gatewayUrl = new URL(selectedGateway);
       gatewayUrl.hostname = `${firstPart}.${gatewayUrl.hostname}`;
-      gatewayUrl.pathname = rest.length > 0 ? `/${rest.join("/")}` : "/";
+      gatewayUrl.pathname = rest.length > 0 ? `/${rest.join('/')}` : '/';
 
       logger?.debug(
         `Routing ArNS name ${firstPart} to ${gatewayUrl.toString()}`,
@@ -107,7 +107,7 @@ export const resolveWayfinderUrl = ({
           originalUrl,
           selectedGateway,
           resolvedUrl: gatewayUrl.toString(),
-        }
+        },
       );
 
       return gatewayUrl;
@@ -117,7 +117,7 @@ export const resolveWayfinderUrl = ({
     // TODO: "gasless" routing via DNS TXT records
   }
 
-  logger?.debug("No wayfinder routing protocol applied", {
+  logger?.debug('No wayfinder routing protocol applied', {
     originalUrl,
   });
 
@@ -134,48 +134,48 @@ export class WayfinderEmitter extends EventEmitter<WayfinderEvent> {
     super();
     if (verification) {
       if (verification.onVerificationSucceeded) {
-        this.on("verification-succeeded", verification.onVerificationSucceeded);
+        this.on('verification-succeeded', verification.onVerificationSucceeded);
       }
       if (verification.onVerificationFailed) {
-        this.on("verification-failed", verification.onVerificationFailed);
+        this.on('verification-failed', verification.onVerificationFailed);
       }
       if (verification.onVerificationProgress) {
-        this.on("verification-progress", verification.onVerificationProgress);
+        this.on('verification-progress', verification.onVerificationProgress);
       }
     }
     if (routing) {
       if (routing.onRoutingStarted) {
-        this.on("routing-started", routing.onRoutingStarted);
+        this.on('routing-started', routing.onRoutingStarted);
       }
       if (routing.onRoutingSkipped) {
-        this.on("routing-skipped", routing.onRoutingSkipped);
+        this.on('routing-skipped', routing.onRoutingSkipped);
       }
       if (routing.onRoutingSucceeded) {
-        this.on("routing-succeeded", routing.onRoutingSucceeded);
+        this.on('routing-succeeded', routing.onRoutingSucceeded);
       }
     }
 
     if (parentEmitter) {
-      this.on("routing-started", (event) => {
-        parentEmitter.emit("routing-started", event);
+      this.on('routing-started', (event) => {
+        parentEmitter.emit('routing-started', event);
       });
-      this.on("routing-skipped", (event) => {
-        parentEmitter.emit("routing-skipped", event);
+      this.on('routing-skipped', (event) => {
+        parentEmitter.emit('routing-skipped', event);
       });
-      this.on("routing-succeeded", (event) => {
-        parentEmitter.emit("routing-succeeded", event);
+      this.on('routing-succeeded', (event) => {
+        parentEmitter.emit('routing-succeeded', event);
       });
-      this.on("verification-succeeded", (event) => {
-        parentEmitter.emit("verification-succeeded", event);
+      this.on('verification-succeeded', (event) => {
+        parentEmitter.emit('verification-succeeded', event);
       });
-      this.on("verification-failed", (event) => {
-        parentEmitter.emit("verification-failed", event);
+      this.on('verification-failed', (event) => {
+        parentEmitter.emit('verification-failed', event);
       });
-      this.on("verification-progress", (event) => {
-        parentEmitter.emit("verification-progress", event);
+      this.on('verification-progress', (event) => {
+        parentEmitter.emit('verification-progress', event);
       });
-      this.on("verification-skipped", (event) => {
-        parentEmitter.emit("verification-skipped", event);
+      this.on('verification-skipped', (event) => {
+        parentEmitter.emit('verification-skipped', event);
       });
     }
   }
@@ -191,14 +191,14 @@ export function tapAndVerifyReadableStream({
 }: {
   originalStream: ReadableStream;
   contentLength: number;
-  verifyData: VerificationStrategy["verifyData"];
+  verifyData: VerificationStrategy['verifyData'];
   txId: string;
   emitter?: WayfinderEmitter;
   strict?: boolean;
 }): ReadableStream {
   if (
     originalStream instanceof ReadableStream &&
-    typeof originalStream.tee === "function"
+    typeof originalStream.tee === 'function'
   ) {
     /**
      * NOTE: tee requires the streams both streams to be consumed, so we need to make sure we consume the client branch
@@ -225,32 +225,32 @@ export function tapAndVerifyReadableStream({
             // in strict mode, we wait for verification to complete before closing the controller
             try {
               await verificationPromise;
-              emitter?.emit("verification-succeeded", { txId });
+              emitter?.emit('verification-succeeded', { txId });
               controller.close();
             } catch (err) {
               // emit the verification failed event
-              emitter?.emit("verification-failed", err);
+              emitter?.emit('verification-failed', err);
 
               // In strict mode, we report the error to the client stream
               controller.error(
-                new Error("Verification failed", { cause: err })
+                new Error('Verification failed', { cause: err }),
               );
             }
           } else {
             // trigger the verification promise and emit events for the result
             verificationPromise
               .then(() => {
-                emitter?.emit("verification-succeeded", { txId });
+                emitter?.emit('verification-succeeded', { txId });
               })
               .catch((error: unknown) => {
-                emitter?.emit("verification-failed", error);
+                emitter?.emit('verification-failed', error);
               });
             // in non-strict mode, we close the controller immediately and handle verification asynchronously
             controller.close();
           }
         } else {
           bytesProcessed += value.length;
-          emitter?.emit("verification-progress", {
+          emitter?.emit('verification-progress', {
             txId,
             totalBytes: contentLength,
             processedBytes: bytesProcessed,
@@ -263,9 +263,9 @@ export function tapAndVerifyReadableStream({
         reader.cancel(reason);
 
         // emit the verification cancellation event
-        emitter?.emit("verification-failed", {
+        emitter?.emit('verification-failed', {
           txId,
-          error: new Error("Verification cancelled", {
+          error: new Error('Verification cancelled', {
             cause: {
               reason,
             },
@@ -275,7 +275,7 @@ export function tapAndVerifyReadableStream({
     });
     return clientStreamWithVerification;
   }
-  throw new Error("Unsupported body type for cloning");
+  throw new Error('Unsupported body type for cloning');
 }
 
 /**
@@ -299,8 +299,8 @@ export const wayfinderFetch = ({
 }: {
   logger?: Logger;
   gatewaysProvider: GatewaysProvider;
-  verificationSettings: NonNullable<WayfinderOptions["verificationSettings"]>;
-  routingSettings: NonNullable<WayfinderOptions["routingSettings"]>;
+  verificationSettings: NonNullable<WayfinderOptions['verificationSettings']>;
+  routingSettings: NonNullable<WayfinderOptions['routingSettings']>;
   emitter?: WayfinderEmitter;
   tracer?: Tracer;
 }) => {
@@ -308,10 +308,10 @@ export const wayfinderFetch = ({
     input: URL | RequestInfo,
     init?: RequestInit & {
       verificationSettings?: NonNullable<
-        WayfinderOptions["verificationSettings"]
+        WayfinderOptions['verificationSettings']
       >;
-      routingSettings?: NonNullable<WayfinderOptions["routingSettings"]>;
-    }
+      routingSettings?: NonNullable<WayfinderOptions['routingSettings']>;
+    },
   ): Promise<Response> => {
     const {
       // allows for overriding the verification and routing settings for a single request
@@ -336,17 +336,17 @@ export const wayfinderFetch = ({
       tracer,
     });
 
-    if (!url.toString().startsWith("ar://")) {
-      logger?.debug("URL is not a wayfinder url, skipping routing", {
+    if (!url.toString().startsWith('ar://')) {
+      logger?.debug('URL is not a wayfinder url, skipping routing', {
         input,
       });
-      requestEmitter.emit("routing-skipped", {
+      requestEmitter.emit('routing-skipped', {
         originalUrl: JSON.stringify(input),
       });
       return fetch(input, init);
     }
 
-    requestEmitter.emit("routing-started", {
+    requestEmitter.emit('routing-started', {
       originalUrl: input.toString(),
     });
 
@@ -358,15 +358,15 @@ export const wayfinderFetch = ({
         // select the target gateway
         const selectedGateway = await routingSettings.strategy?.selectGateway({
           gateways: await gatewaysProvider.getGateways(),
-          path: url.split("/").slice(1).join("/"), // everything after the first /
-          subdomain: "",
+          path: url.split('/').slice(1).join('/'), // everything after the first /
+          subdomain: '',
         });
 
         if (!selectedGateway) {
-          throw new Error("Failed to select a gateway");
+          throw new Error('Failed to select a gateway');
         }
 
-        logger?.debug("Selected gateway", {
+        logger?.debug('Selected gateway', {
           originalUrl: url,
           selectedGateway: selectedGateway?.toString(),
         });
@@ -378,7 +378,7 @@ export const wayfinderFetch = ({
           logger,
         });
 
-        requestEmitter.emit("routing-succeeded", {
+        requestEmitter.emit('routing-succeeded', {
           originalUrl: url,
           selectedGateway: selectedGateway.toString(),
           redirectUrl: redirectUrl.toString(),
@@ -391,23 +391,23 @@ export const wayfinderFetch = ({
 
         const requestSpan = parentSpan
           ? tracer?.startSpan(
-              "wayfinder.fetch",
+              'wayfinder.fetch',
               undefined,
-              trace.setSpan(context.active(), parentSpan)
+              trace.setSpan(context.active(), parentSpan),
             )
           : undefined;
 
         // make the request to the target gateway using the redirect url
         const response = await fetch(redirectUrl.toString(), {
           // enforce CORS given we're likely going to a different origin, but always allow the client to override
-          redirect: "follow",
-          mode: "cors",
+          redirect: 'follow',
+          mode: 'cors',
           ...restInit,
         });
 
         // add response attributes to the span
-        requestSpan?.setAttribute("response.status", response.status);
-        requestSpan?.setAttribute("response.statusText", response.statusText);
+        requestSpan?.setAttribute('response.status', response.status);
+        requestSpan?.setAttribute('response.statusText', response.statusText);
         response.headers.forEach((value, key) => {
           requestSpan?.setAttribute(`response.headers.${key}`, value);
         });
@@ -420,13 +420,13 @@ export const wayfinderFetch = ({
         // only verify data if the redirect url is different from the original url
         if (redirectUrl.toString() === url) {
           logger?.debug(
-            "Redirect URL is the same as the original URL, skipping verification",
+            'Redirect URL is the same as the original URL, skipping verification',
             {
               redirectUrl: redirectUrl.toString(),
               originalUrl: url,
-            }
+            },
           );
-          requestEmitter.emit("verification-skipped", {
+          requestEmitter.emit('verification-skipped', {
             originalUrl: url,
           });
           requestSpan?.end();
@@ -441,13 +441,13 @@ export const wayfinderFetch = ({
           )
         ) {
           logger?.debug(
-            "Verification is disabled or no verification strategy is provided, skipping verification",
+            'Verification is disabled or no verification strategy is provided, skipping verification',
             {
               redirectUrl: redirectUrl.toString(),
               originalUrl: url,
-            }
+            },
           );
-          requestEmitter.emit("verification-skipped", {
+          requestEmitter.emit('verification-skipped', {
             originalUrl: url,
           });
           requestSpan?.end();
@@ -461,22 +461,22 @@ export const wayfinderFetch = ({
 
         // transaction id is either in the response headers or the path of the request as the first parameter
         const txId =
-          headers.get("x-arns-resolved-id") ??
-          redirectUrl.pathname.split("/")[1];
+          headers.get('x-arns-resolved-id') ??
+          redirectUrl.pathname.split('/')[1];
 
-        const contentLength = +(headers.get("content-length") ?? 0);
+        const contentLength = +(headers.get('content-length') ?? 0);
 
-        requestSpan?.setAttribute("txId", txId);
-        requestSpan?.setAttribute("contentLength", contentLength);
+        requestSpan?.setAttribute('txId', txId);
+        requestSpan?.setAttribute('contentLength', contentLength);
         requestSpan?.end();
 
         if (!txIdRegex.test(txId)) {
           // no transaction id found, skip verification
-          logger?.debug("No transaction id found, skipping verification", {
+          logger?.debug('No transaction id found, skipping verification', {
             redirectUrl: redirectUrl.toString(),
             originalUrl: url,
           });
-          requestEmitter.emit("verification-skipped", {
+          requestEmitter.emit('verification-skipped', {
             originalUrl: url,
           });
           return response;
@@ -488,7 +488,7 @@ export const wayfinderFetch = ({
             originalStream: response.body,
             contentLength,
             verifyData: verificationSettings.strategy?.verifyData.bind(
-              verificationSettings.strategy
+              verificationSettings.strategy,
             ),
             txId,
             emitter: requestEmitter,
@@ -502,7 +502,7 @@ export const wayfinderFetch = ({
           });
         } else {
           // No response body to verify, skip verification
-          logger?.debug("No response body to verify", {
+          logger?.debug('No response body to verify', {
             redirectUrl: redirectUrl.toString(),
             originalUrl: url,
             txId,
@@ -510,7 +510,7 @@ export const wayfinderFetch = ({
           return response;
         }
       } catch (error: any) {
-        logger?.debug("Failed to route request", {
+        logger?.debug('Failed to route request', {
           error: error.message,
           stack: error.stack,
           originalUrl: url,
@@ -523,7 +523,7 @@ export const wayfinderFetch = ({
       }
     }
 
-    throw new Error("Failed to route request after max retries", {
+    throw new Error('Failed to route request after max retries', {
       cause: {
         originalUrl: url,
         maxRetries,
@@ -555,12 +555,12 @@ export class Wayfinder {
    * If not provided, the default FastestPingRoutingStrategy will be used.
    */
   public readonly routingSettings: Required<
-    NonNullable<WayfinderOptions["routingSettings"]>
+    NonNullable<WayfinderOptions['routingSettings']>
   >;
   /**
    * The verification settings to use when verifying data.
    */
-  public readonly verificationSettings: WayfinderOptions["verificationSettings"];
+  public readonly verificationSettings: WayfinderOptions['verificationSettings'];
 
   /**
    * Telemetry configuration used for OpenTelemetry tracing
@@ -708,7 +708,7 @@ export class Wayfinder {
         verificationSettings?.enabled ??
         verificationSettings?.strategy !== undefined,
       strategy: new HashVerificationStrategy({
-        trustedGateways: [new URL("https://permagate.io")],
+        trustedGateways: [new URL('https://permagate.io')],
       }),
       // overwrite the default settings with the provided ones
       ...verificationSettings,
@@ -753,7 +753,7 @@ export class Wayfinder {
       const selectedGateway = await this.routingSettings.strategy.selectGateway(
         {
           gateways: await this.gatewaysProvider.getGateways(),
-        }
+        },
       );
 
       return resolveWayfinderUrl({
@@ -763,7 +763,7 @@ export class Wayfinder {
       });
     };
 
-    this.logger.debug("Wayfinder initialized", {
+    this.logger.debug('Wayfinder initialized', {
       verificationSettings: this.verificationSettings,
       routingSettings: this.routingSettings,
       telemetrySettings: this.telemetrySettings,


### PR DESCRIPTION
## Description

  Fixes ArNS subdomain routing issue where ArNS names were incorrectly routed using path-based URLs (e.g.,
  `gateway.com/arnsname`) instead of subdomain-based URLs (e.g., `arnsname.gateway.com`).

  ## Problem

  The `wayfinderFetch` function was always passing an empty `subdomain` parameter to `selectGateway`, causing
  `resolveWayfinderUrl` to default to path-based routing for all requests.

  ## Solution

  Updated `resolveWayfinderUrl` to:
  - Use the URL API consistently for hostname and pathname manipulation
  - Properly prepend ArNS names as subdomains to the gateway hostname
  - Handle multi-level gateway domains correctly (e.g., `my.gateway.com` → `arnsname.my.gateway.com`)
  - Preserve ports and protocols automatically through URL API