### PR TITLE
fix(core): fix zone.js import causing global collisions in browsers

### DIFF
--- a/packages/core/src/utils/zone.ts
+++ b/packages/core/src/utils/zone.ts
@@ -1,0 +1,34 @@
+/**
+ * WayFinder
+ * Copyright (C) 2022-2025 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { defaultLogger } from '../logger.js';
+import { isBrowser } from './browser.js';
+
+export async function loadZonePolyfill() {
+  // If Zone is already loaded, skip import
+  if (isBrowser() && typeof (window as any).Zone === 'undefined') {
+    defaultLogger.info('Loading zone.js polyfill');
+    await import('zone.js');
+  }
+}
+
+export function assertZoneLoaded() {
+  if (isBrowser() && typeof (window as any).Zone === 'undefined') {
+    throw new Error(
+      'Zone.js is not loaded. Please add zone.js to your project and call loadZonePolyfill() before initializing Wayfinder.',
+    );
+  }
+}


### PR DESCRIPTION
This direct import should only happen once, and only if in browsers