### PR TITLE
fix(wayfinder-core): handle missing arguments in createWayfinderClient

### DIFF
--- a/.changeset/shaky-days-travel.md
+++ b/.changeset/shaky-days-travel.md
@@ -1,0 +1,5 @@
+---
+"@ar.io/wayfinder-core": patch
+---
+
+fix: allow createWayfinderClient to initialize with default configuration when no arguments are provided

--- a/packages/wayfinder-core/src/client.ts
+++ b/packages/wayfinder-core/src/client.ts
@@ -197,7 +197,7 @@ export function createWayfinderClient(
     gatewaysProvider: customGatewaysProvider,
     routingStrategy: customRoutingStrategy,
     verificationStrategy: customVerificationStrategy,
-    preferredGateway = 'arweave.net',
+    preferredGateway = 'https://arweave.net',
     fallbackStrategy = 'random',
   } = options;
 

--- a/packages/wayfinder-core/src/routing/round-robin.ts
+++ b/packages/wayfinder-core/src/routing/round-robin.ts
@@ -27,7 +27,7 @@ export class RoundRobinRoutingStrategy implements RoutingStrategy {
   constructor({
     gateways = [
       new URL('https://arweave.net'),
-      new URL('https://permagate.io'),
+      new URL('https://permagate.io')
     ],
     logger = defaultLogger,
     gatewaysProvider,

--- a/packages/wayfinder-core/src/routing/round-robin.ts
+++ b/packages/wayfinder-core/src/routing/round-robin.ts
@@ -25,7 +25,10 @@ export class RoundRobinRoutingStrategy implements RoutingStrategy {
   private gatewaysProvider?: GatewaysProvider;
 
   constructor({
-    gateways,
+    gateways = [
+      new URL('https://arweave.net'),
+      new URL('https://permagate.io'),
+    ],
     logger = defaultLogger,
     gatewaysProvider,
   }: {

--- a/packages/wayfinder-core/src/version.ts
+++ b/packages/wayfinder-core/src/version.ts
@@ -14,4 +14,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export const WAYFINDER_CORE_VERSION = 'v1.3.1';
+export const WAYFINDER_CORE_VERSION = 'v1.4.0-alpha.2';


### PR DESCRIPTION
# Pull Request Guidelines

Thank you for contributing! Please review the following guidelines before submitting your pull request:

- **Review the [CONTRIBUTING](https://github.com/ar-io/wayfinder/blob/main/README.md#contributing) section for full details and requirements.**
- By submitting a PR, you agree to license your contribution under the repository's [LICENSE](https://github.com/ar-io/ar-io-sdk/blob/main/LICENSE.md).

## Checklist (please complete before submitting)

- [x ] My PR is against the correct branch (see CONTRIBUTING.md for branch policy)
- [ x] My commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) style
- [ x] My commit messages clearly explain the reasons for the changes
- [ x] I have followed the [architecture guidelines](https://github.com/ar-io/wayfinder/tree/main#architecture)
- [ x] I have run lint and format checks ([see instructions](https://github.com/ar-io/wayfinder/tree/main#linting--formatting))
- [ x] I have run all tests ([see instructions](https://github.com/ar-io/wayfinder/tree/main#testing))
- [ x] I have run `npx changeset` to document my changes ([see instructions](https://github.com/ar-io/wayfinder/tree/main#creating-a-changeset))
- [ x] I have checked for existing issues/PRs to avoid duplicates

## Additional Notes

This PR fixes createWayfinderClient when initialized with no values. By adding default gateways to round-robin, we avoid hitting `Must provide either gateways or gatewaysProvider` in the browser environment 

Closes #152 
