### PR TITLE
fix(logging): ensure default objects are using custom logger.

### DIFF
--- a/packages/wayfinder-core/src/wayfinder.ts
+++ b/packages/wayfinder-core/src/wayfinder.ts
@@ -700,6 +700,7 @@ export class Wayfinder {
       strategy:
         (verificationSettings?.strategy ?? verificationSettings?.enabled)
           ? new HashVerificationStrategy({
+              logger,
               trustedGateways: [new URL('https://permagate.io')],
             })
           : undefined,
@@ -711,7 +712,8 @@ export class Wayfinder {
     this.routingSettings = {
       events: {},
       strategy: new PingRoutingStrategy({
-        routingStrategy: new RandomRoutingStrategy(),
+        logger,
+        routingStrategy: new RandomRoutingStrategy({logger}),
       }),
       // overwrite the default settings with the provided ones
       ...routingSettings,
@@ -842,6 +844,7 @@ export class Wayfinder {
       strategy ??
       this.verificationSettings.strategy ??
       new HashVerificationStrategy({
+        logger: this.logger,
         trustedGateways: [new URL('https://permagate.io')],
       });
   }


### PR DESCRIPTION
Issue: Wayfinder class creates default objects, which are all using the default logger instead of the one configured for Wayfinder.

Solution: pass the logger configured for Wayfinder along to the default objects it creates.

# Pull Request Guidelines

Thank you for contributing! Please review the following guidelines before submitting your pull request:

- **Review the [CONTRIBUTING](https://github.com/ar-io/wayfinder/blob/main/README.md#contributing) section for full details and requirements.**
- By submitting a PR, you agree to license your contribution under the repository's [LICENSE](https://github.com/ar-io/ar-io-sdk/blob/main/LICENSE.md).

## Checklist (please complete before submitting)

- [x] My PR is against the correct branch (see CONTRIBUTING.md for branch policy)
- [x] My commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) style
- [x] My commit messages clearly explain the reasons for the changes
- [x] I have followed the [architecture guidelines](https://github.com/ar-io/wayfinder/tree/main#architecture)
- [x] I have run lint and format checks ([see instructions](https://github.com/ar-io/wayfinder/tree/main#linting--formatting))
- [x] I have run all tests ([see instructions](https://github.com/ar-io/wayfinder/tree/main#testing))
- [x] I have run `npx changeset` to document my changes ([see instructions](https://github.com/ar-io/wayfinder/tree/main#creating-a-changeset))
- [x] I have checked for existing issues/PRs to avoid duplicates

## Additional Notes

- Provide a clear and concise description of your changes and the problem they solve.
- If your PR addresses an open issue, please reference it in the description (e.g., `Closes #123`).
- For more details, see the [CONTRIBUTING](https://github.com/ar-io/wayfinder/blob/main/README.md#contributing) section.
