### PR TITLE
feat(core): change default gateway provider to TrustedPeersGatewaysProvider

### DIFF
--- a/.changeset/trusted-peers-default.md
+++ b/.changeset/trusted-peers-default.md
@@ -1,0 +1,5 @@
+---
+"@ar.io/wayfinder-core": minor
+---
+
+Change default gateway provider to TrustedPeersGatewaysProvider for dynamic gateway discovery

--- a/packages/wayfinder-core/README.md
+++ b/packages/wayfinder-core/README.md
@@ -19,7 +19,7 @@ yarn add @ar.io/wayfinder-core
 ```javascript
 import { createWayfinderClient } from '@ar.io/wayfinder-core';
 
-// Uses static gateways by default
+// Uses trusted peers gateway provider by default
 const wayfinder = createWayfinderClient();
 
 // Use Wayfinder to fetch and verify data using ar:// protocol
@@ -39,14 +39,14 @@ const wayfinder = createWayfinderClient({
 });
 ```
 
-### Static Gateways with Custom Options
+### Custom Trusted Gateway
 
 ```javascript
 import { createWayfinderClient } from '@ar.io/wayfinder-core';
 
-// Use custom static gateways
+// Use a specific trusted gateway for fetching peers
 const wayfinder = createWayfinderClient({
-  trustedGateways: ['https://permagate.io', 'https://arweave.net'],
+  trustedGateways: ['https://permagate.io'], // First gateway is used for TrustedPeersGatewaysProvider
   routing: 'fastest',
   verification: 'hash',
 });
@@ -162,7 +162,7 @@ const redirectUrl = await wayfinder.resolveUrl({
 
 ## Gateway Providers
 
-Gateway providers are responsible for providing a list of gateways to Wayfinder to choose from when routing requests. By default, Wayfinder will use the `NetworkGatewaysProvider` to get a list of gateways from the ARIO Network.
+Gateway providers are responsible for providing a list of gateways to Wayfinder to choose from when routing requests. By default, Wayfinder will use the `TrustedPeersGatewaysProvider` to fetch available gateways from a trusted gateway's peer list.
 
 ### NetworkGatewaysProvider
 
@@ -180,6 +180,21 @@ const gatewayProvider = new NetworkGatewaysProvider({
     return gateway.status === 'joined' && gateway.stats.failedConsecutiveEpochs === 0;
   },
 });
+```
+
+### TrustedPeersGatewaysProvider
+
+Fetches a dynamic list of trusted peer gateways from an AR.IO gateway's `/ar-io/peers` endpoint. This provider is useful for discovering available gateways from a trusted source.
+
+```javascript
+import { TrustedPeersGatewaysProvider } from '@ar.io/wayfinder-core';
+
+const gatewayProvider = new TrustedPeersGatewaysProvider({
+  trustedGateway: 'https://arweave.net', // Gateway to fetch peers from
+});
+
+// The provider will fetch the peer list from https://arweave.net/ar-io/peers
+// and return an array of gateway URLs from the response
 ```
 
 ### StaticGatewaysProvider

--- a/packages/wayfinder-core/src/client.ts
+++ b/packages/wayfinder-core/src/client.ts
@@ -19,7 +19,7 @@ import type { AoARIORead } from '@ar.io/sdk';
 import { LocalStorageGatewaysProvider } from './gateways/local-storage-cache.js';
 import { NetworkGatewaysProvider } from './gateways/network.js';
 import { SimpleCacheGatewaysProvider } from './gateways/simple-cache.js';
-import { StaticGatewaysProvider } from './gateways/static.js';
+import { TrustedPeersGatewaysProvider } from './gateways/trusted-peers.js';
 import { FastestPingRoutingStrategy } from './routing/ping.js';
 import { PreferredWithFallbackRoutingStrategy } from './routing/preferred-with-fallback.js';
 import { RandomRoutingStrategy } from './routing/random.js';
@@ -226,15 +226,10 @@ export function createWayfinderClient(
       limit: 10,
     });
   } else {
-    // Fall back to static gateways when no ARIO instance is provided
-    gatewaysProvider = new StaticGatewaysProvider({
-      gateways: trustedGateways.length
-        ? trustedGateways
-        : [
-            'https://permagate.io',
-            'https://arweave.net',
-            'https://ardrive.net',
-          ],
+    // Fall back to trusted peers gateway provider when no ARIO instance is provided
+    gatewaysProvider = new TrustedPeersGatewaysProvider({
+      trustedGateway: trustedGateways[0] || 'https://arweave.net',
+      logger,
     });
   }
 

--- a/packages/wayfinder-core/src/wayfinder.ts
+++ b/packages/wayfinder-core/src/wayfinder.ts
@@ -21,7 +21,7 @@ import { Span, type Tracer, context, trace } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
 import { WayfinderEmitter } from './emitter.js';
-import { StaticGatewaysProvider } from './gateways/static.js';
+import { TrustedPeersGatewaysProvider } from './gateways/trusted-peers.js';
 import { PingRoutingStrategy } from './routing/ping.js';
 import { RandomRoutingStrategy } from './routing/random.js';
 import { initTelemetry, startRequestSpans } from './telemetry.js';
@@ -682,12 +682,9 @@ export class Wayfinder {
     // default gateways provider to use if no provider is provided
     this.gatewaysProvider =
       gatewaysProvider ??
-      new StaticGatewaysProvider({
-        gateways: [
-          'https://permagate.io',
-          'https://arweave.net',
-          'https://ardrive.net',
-        ],
+      new TrustedPeersGatewaysProvider({
+        trustedGateway: 'https://arweave.net',
+        logger: this.logger,
       });
 
     // default verification settings


### PR DESCRIPTION
## Summary
- Changes the default gateway provider from `StaticGatewaysProvider` to `TrustedPeersGatewaysProvider`
- Enables dynamic gateway discovery by default instead of using a static list
- Updates documentation to reflect the new default behavior

## Changes
1. **client.ts**: Updated fallback gateway provider to use `TrustedPeersGatewaysProvider` with the first trusted gateway (defaulting to 'https://arweave.net')
2. **wayfinder.ts**: Changed default gateway provider in constructor to use `TrustedPeersGatewaysProvider` with 'https://arweave.net'
3. **README.md**: 
   - Updated basic usage documentation
   - Added documentation for `TrustedPeersGatewaysProvider`
   - Updated gateway providers section to indicate the new default

## Benefits
- Dynamic gateway discovery: The gateway list is fetched from the trusted gateway's `/ar-io/peers` endpoint
- More flexibility: Gateway list can be updated without code changes
- Better resilience: Automatically discovers available gateways from the network

## Test plan
- [ ] Verify that `createWayfinderClient()` without options uses `TrustedPeersGatewaysProvider`
- [ ] Test that the provider correctly fetches peers from the `/ar-io/peers` endpoint
- [ ] Ensure backward compatibility with existing configurations
- [ ] Verify that custom gateway providers still override the default

🤖 Generated with [Claude Code](https://claude.ai/code)