### PR TITLE
Fix/background async sendresponse extension

### DIFF
--- a/.changeset/hot-apes-care.md
+++ b/.changeset/hot-apes-care.md
@@ -1,0 +1,5 @@
+---
+"@ar.io/wayfinder-extension": patch
+---
+
+fix(extension): ensure async messages in background return responses


### PR DESCRIPTION
## Checklist (please complete before submitting)

- [ x] My PR is against the correct branch (see CONTRIBUTING.md for branch policy)
- [x ] My commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) style
- [x ] My commit messages clearly explain the reasons for the changes
- [x ] I have followed the [architecture guidelines](https://github.com/ar-io/wayfinder/tree/main#architecture)
- [x ] I have run lint and format checks ([see instructions](https://github.com/ar-io/wayfinder/tree/main#linting--formatting))
- [x ] I have run all tests ([see instructions](https://github.com/ar-io/wayfinder/tree/main#testing))
- [x ] I have run `npx changeset` to document my changes ([see instructions](https://github.com/ar-io/wayfinder/tree/main#creating-a-changeset))
- [ x] I have checked for existing issues/PRs to avoid duplicates

## Additional Notes

Fix async message handling in extension background script to return proper responses on routing strategy change. 

------
### Explanation
When sending messages to the extension’s background script with `chrome.runtime.sendMessage`, the caller often received `undefined` instead of the expected response.  

This happened because the background listener was defined as `async`, but Chrome does not await the returned Promise.  
For handlers with `await` calls, `sendResponse` was invoked after the message channel had already closed.  
As a result, the response never reached the sender(the response was always `undefined`   


### Solution 
Refactored the background listener so that:  
- Async operations are wrapped in an immediately-invoked function.  
- `return true;` in each async branch to keep the message channel open until `sendResponse` is called.  
- Synchronous branches remain unchanged.  
