### PR TITLE
fix(cli): address missing `axios` error in wayfinder-cli, add header for selected gateway to wayfinder-core

### DIFF
--- a/.changeset/few-days-prove.md
+++ b/.changeset/few-days-prove.md
@@ -1,0 +1,5 @@
+---
+"@ar.io/wayfinder-core": patch
+---
+
+Add `x-ar-io-gateway-url` header to Response object for traceability of what gateway served the reqested data'

--- a/experimental/wayfinder-cli/package.json
+++ b/experimental/wayfinder-cli/package.json
@@ -37,6 +37,7 @@
   "homepage": "https://github.com/ar-io/wayfinder/tree/main/experimental/wayfinder-cli#readme",
   "dependencies": {
     "@ar.io/wayfinder-core": "1.9.2",
+    "axios": "^1.13.6",
     "chalk": "^5.3.0",
     "cli-progress": "^3.12.0",
     "commander": "^12.1.0",

--- a/experimental/wayfinder-cli/src/commands/fetch.ts
+++ b/experimental/wayfinder-cli/src/commands/fetch.ts
@@ -116,7 +116,7 @@ export const fetchCommand = new Command('fetch')
         }
 
         // Extract metadata
-        gateway = response.headers.get('x-wayfinder-url') || undefined;
+        gateway = response.headers.get('x-ar-io-gateway-url') || undefined;
         contentType = response.headers.get('content-type') || undefined;
         txId = response.headers.get('x-ar-io-data-id') || 'unknown';
         const contentLengthHeader = response.headers.get('content-length');

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@ar.io/wayfinder-core": "1.8.0",
+        "axios": "^1.12.0",
         "chalk": "^5.3.0",
         "cli-progress": "^3.12.0",
         "commander": "^12.1.0",

--- a/packages/wayfinder-core/src/fetch/wayfinder-fetch.ts
+++ b/packages/wayfinder-core/src/fetch/wayfinder-fetch.ts
@@ -245,7 +245,13 @@ export const createWayfinderFetch = ({
       }
 
       return new Response(finalStream, {
-        headers: dataResponse.headers,
+        headers: {
+          ...dataResponse.headers,
+          // Response objects do not let you specify the url, which would normally tell you what gateway the data came from. To work around this, we add a custom header with the gateway URL for observability purposes.
+          // This is important for users to be able to see which gateway served the data, especially when using multiple gateways or routing strategies that may select different gateways for different requests.
+          // Note that this header is only for informational purposes and should not be used for any security-sensitive logic, as headers can be spoofed. It's purely to provide visibility into the routing decisions made by Wayfinder.
+          'x-ar-io-gateway-url': selectedGateway.toString(),
+        },
         status: dataResponse.status,
         statusText: dataResponse.statusText,
       });


### PR DESCRIPTION
Arbundles requires axios but does not include it as a dependency.

Steps to take:
- merge this PR to alpha, then alpha to main to release the wayfinder-core fix
- once wayfinder-core is updated, update the `package.json` of wayfinder-cli and run `npm i && npm run build`
- manually publish `wayfinder-cli` via `npm publish` - docs [here](https://docs.npmjs.com/cli/v8/commands/npm-publish)

Note:
If you want wayfinder-cli to be included in automated publishing, I _think_ you can just move the `wayfinder-cli` directory to `packages` and changeset will start to tag/release it on any version bumps of wayfinder-core
