### PR TITLE
refactor(extension): add Solana network type/constant/default scaffolding

### DIFF
--- a/.changeset/extension-solana-foundation.md
+++ b/.changeset/extension-solana-foundation.md
@@ -1,0 +1,21 @@
+---
+"@ar.io/wayfinder-extension": patch
+---
+
+Internal: add Solana-network type definitions, constants, and defaults
+in preparation for the AO → Solana migration.
+
+- New `NetworkPreset` type (`'mainnet' | 'devnet' | 'custom'`) and
+  `SolanaNetworkConfig` shape in `src/types.ts`.
+- `AR_IO_SOLANA_DEVNET` preset constant in `src/constants.ts` carrying
+  the public devnet RPC URL and the four AR.IO program addresses (core,
+  GAR, ArNS, ANT). `AR_IO_SOLANA_MAINNET` placeholder is `null` until
+  AR.IO Solana mainnet deploys.
+- `SOLANA_NETWORK_DEFAULTS` export in `src/config/defaults.ts` for use
+  by the upcoming migration commit.
+
+This commit is purely additive — no existing code consumes the new
+exports yet, so there is no runtime behavior change. The subsequent
+PR will switch the extension's initialization and settings paths from
+AO to Solana, removing the AO-era constants, dropping
+`@permaweb/aoconnect`, and bumping `@ar.io/sdk` to `^4.0.0-solana.8`.

--- a/packages/wayfinder-extension/src/config/defaults.ts
+++ b/packages/wayfinder-extension/src/config/defaults.ts
@@ -17,9 +17,22 @@
 
 import {
   ARIO_MAINNET_PROCESS_ID,
+  AR_IO_SOLANA_DEVNET,
   DEFAULT_AO_CU_URL,
   FALLBACK_GATEWAY,
 } from '../constants';
+import type { NetworkPreset } from '../types';
+
+/**
+ * AR.IO Solana network configuration defaults applied on first install.
+ * Active preset is `devnet` (AR.IO Solana mainnet is not yet deployed).
+ * Stored as flat keys in `chrome.storage.local` for easy diffing and
+ * incremental updates from the settings UI.
+ */
+export const SOLANA_NETWORK_DEFAULTS = {
+  network: 'devnet' satisfies NetworkPreset as NetworkPreset,
+  ...AR_IO_SOLANA_DEVNET,
+} as const;
 
 /**
  * Core extension defaults

--- a/packages/wayfinder-extension/src/constants.ts
+++ b/packages/wayfinder-extension/src/constants.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 import { AoGatewayWithAddress } from '@ar.io/sdk/web';
+import { SolanaNetworkConfig } from './types';
 
 // Last resort fallback gateway - only used when AR.IO network is unreachable
 export const FALLBACK_GATEWAY: AoGatewayWithAddress = {
@@ -66,6 +67,41 @@ export const ARIO_MAINNET_PROCESS_ID =
   'qNvAoz0TgcH7DMg8BCVn8jF32QH5L6T29VjHxhHqqGE';
 export const GASLESS_ARNS_DNS_EXPIRATION_TIME = 15 * 60 * 1000; // 15 minutes
 export const DEFAULT_AO_CU_URL = 'https://cu.ardrive.io';
+
+/**
+ * AR.IO Solana devnet program addresses. Mirrors
+ * `ar-io-solana-contracts/program-ids/devnet.json`. The default RPC URL
+ * is the public Solana devnet endpoint, which is heavily rate-limited;
+ * users hitting limits should switch to the `custom` network preset and
+ * supply their own RPC (QuickNode, Helius, etc.).
+ */
+export const AR_IO_SOLANA_DEVNET: SolanaNetworkConfig = {
+  rpcUrl: 'https://api.devnet.solana.com',
+  coreProgramId: '83CQLP848zzCgnZ4LTq87g6hvxTooNLX7YXXkUUGv5ig',
+  garProgramId: 'AF8QAEaR4hzsqeUDwEdeTXMYtdyFegTENBdnJro6WVLR',
+  arnsProgramId: '2HgSCKYjcapJPdHRKqkLrGXm7kvBmCP45ZyhWEm87oM1',
+  antProgramId: '8ZMuXhiK7DorjPUg8RB1rzu7CvsABMk38WDJRbM62y2C',
+};
+
+/**
+ * AR.IO Solana mainnet program addresses. Mainnet is not yet deployed
+ * (as of 2026-05); this stays `null` until the AR.IO contracts ship on
+ * Solana mainnet. The `mainnet` preset in the settings UI is disabled
+ * until this is non-null.
+ */
+export const AR_IO_SOLANA_MAINNET: SolanaNetworkConfig | null = null;
+
+/**
+ * Preset lookup keyed by `NetworkPreset`. `custom` has no preset value
+ * (consumer-supplied at runtime). `mainnet` may be null until deployed.
+ */
+export const AR_IO_SOLANA_PRESETS: Record<
+  'devnet' | 'mainnet',
+  SolanaNetworkConfig | null
+> = {
+  devnet: AR_IO_SOLANA_DEVNET,
+  mainnet: AR_IO_SOLANA_MAINNET,
+};
 export const TOP_ONCHAIN_GATEWAY_LIMIT = 25; // The top amount of gateways returned for onchain performance ranking
 export const DNS_LOOKUP_API = 'https://dns.google/resolve';
 // Legacy routing constants removed - extension now uses simple string values

--- a/packages/wayfinder-extension/src/types.ts
+++ b/packages/wayfinder-extension/src/types.ts
@@ -32,6 +32,27 @@ export type RedirectedTabInfo = {
 
 export type GatewayRegistry = Record<string, AoGatewayWithAddress>;
 
+/**
+ * Identifier for an AR.IO Solana network deployment. `mainnet` is reserved
+ * for the eventual AR.IO Solana mainnet deployment (not yet live as of
+ * 2026-05); `devnet` targets the currently-live AR.IO devnet contracts;
+ * `custom` lets advanced users plug in their own RPC + program IDs (e.g.,
+ * for localnet development).
+ */
+export type NetworkPreset = 'mainnet' | 'devnet' | 'custom';
+
+/**
+ * Solana endpoint + AR.IO program addresses for a single network. All
+ * program IDs are base58-encoded Solana pubkeys.
+ */
+export type SolanaNetworkConfig = {
+  rpcUrl: string;
+  coreProgramId: string;
+  garProgramId: string;
+  arnsProgramId: string;
+  antProgramId: string;
+};
+
 export type VerificationCacheEntry = {
   txId: string;
   verified: boolean;


### PR DESCRIPTION
## Summary

Foundation work for the AO → Solana migration. **Purely additive — no existing code consumes the new exports yet, so this PR introduces zero runtime behavior change.** PR A of two.

## What's added

- **`src/types.ts`**
  - `NetworkPreset` enum (`'mainnet' | 'devnet' | 'custom'`)
  - `SolanaNetworkConfig` shape (`rpcUrl` + 4 program IDs)

- **`src/constants.ts`**
  - `AR_IO_SOLANA_DEVNET` preset carrying the public devnet RPC and the four program addresses (core / GAR / ArNS / ANT) from [`ar-io-solana-contracts/program-ids/devnet.json`](https://github.com/ar-io/ar-io-solana-contracts/blob/develop/program-ids/devnet.json). Docstring notes the public RPC's rate limits.
  - `AR_IO_SOLANA_MAINNET = null` placeholder. AR.IO Solana mainnet is not yet deployed; this stays null until it is.
  - `AR_IO_SOLANA_PRESETS` keyed lookup for use by the settings UI.

- **`src/config/defaults.ts`**
  - `SOLANA_NETWORK_DEFAULTS = { network: 'devnet', ...devnet preset }` for the upcoming migration commit to populate `EXTENSION_DEFAULTS` / `chrome.storage` on first install.

## What's not in this PR (by design)

This is the additive foundation. The follow-up PR will do the actual migration:

- Rewrite the 4× `ARIO.init({process: new AOProcess(...)})` call sites in `background.ts` + `settings.ts`
- Replace "AR.IO Process ID" / "AO Compute Unit URL" inputs in `settings.html` with network preset selector + Solana RPC + advanced program IDs
- Add storage migration logic (silent reset to devnet defaults + force GAR resync for AO-era users)
- Drop `@permaweb/aoconnect` from dependencies
- Bump `@ar.io/sdk` to `^4.0.0-solana.8`

## Test plan

- [x] `npm run build -w @ar.io/wayfinder-extension` passes (tsc + bundle)
- [x] `biome check` clean
- [x] No existing code consumes the new exports — no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)