### PR TITLE
refactor(extension)!: drop AO entirely; route through Solana

### DIFF
--- a/.changeset/extension-solana-only.md
+++ b/.changeset/extension-solana-only.md
@@ -1,0 +1,56 @@
+---
+"@ar.io/wayfinder-extension": major
+---
+
+BREAKING: Wayfinder extension is now Solana-only. AO support has been
+removed.
+
+**Storage schema (breaking for AO-era users):**
+
+- The `processId` and `aoCuUrl` keys in `chrome.storage.local` are no
+  longer used. On first run after upgrade, the extension detects them,
+  silently deletes them, drops the cached `localGatewayAddressRegistry`
+  (the AO gateway snapshot is irrelevant on Solana), and writes Solana
+  devnet defaults: `network`, `rpcUrl`, `coreProgramId`, `garProgramId`,
+  `arnsProgramId`, `antProgramId`. The next gateway sync repopulates the
+  registry from the Solana network.
+- A single info-level log line is emitted on migration so the migration
+  is visible in devtools.
+
+**Settings UI:**
+
+- "AR.IO Process ID" and "AO Compute Unit URL" fields removed.
+- Replaced with: a Network preset selector
+  (`mainnet | devnet | custom`), a Solana RPC URL input, and a
+  collapsible "Advanced: AR.IO Program IDs" panel exposing the four
+  per-program addresses (core / GAR / ArNS / ANT). Preset modes auto-
+  fill the RPC + program IDs and disable those inputs; Custom mode
+  re-enables them for advanced operators (e.g., localnet developers).
+- `mainnet` preset is `<option disabled>` until AR.IO Solana mainnet is
+  deployed; the default preset on a fresh install is `devnet`.
+
+**Dependencies:**
+
+- Bumped `@ar.io/sdk` from `^3.21.0` to `^4.0.0-solana.8`.
+- Added `@solana/kit` (Solana JS client used by the SDK's Solana
+  backend).
+- Removed `@permaweb/aoconnect` (no longer needed).
+
+**Code:**
+
+- `src/background.ts`: dropped `AOProcess` / `connect` / AO process
+  constants imports; added `arioFromStorage()` helper that constructs
+  a Solana-backed `ARIO.init({backend: 'solana', rpc, ...programIds})`
+  from `chrome.storage.local`; rewrote the four `ARIO.init` call sites
+  to use the helper; added `migrateStorageFromAOEra()` to handle the
+  storage schema bump.
+- `src/settings.ts`: replaced `handleProcessIdChange` /
+  `handleAoCuUrlChange` with a single `handleNetworkConfigChange`
+  routed to all six new field IDs; preset selection auto-fills RPC and
+  program IDs; per-field edits validate the input
+  (URL parsing for RPC, base58 Solana address parsing for program IDs).
+- `src/constants.ts`: removed `ARIO_MAINNET_PROCESS_ID`,
+  `DEFAULT_AO_CU_URL`.
+- `src/config/defaults.ts`: replaced AO defaults
+  (`processId`, `aoCuUrl`) with Solana devnet defaults
+  (`network`, `rpcUrl`, four program IDs).

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
       "version": "22.19.7",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -256,15 +257,21 @@
       "license": "MIT"
     },
     "node_modules/@ar.io/sdk": {
-      "version": "3.23.1",
-      "resolved": "https://registry.npmjs.org/@ar.io/sdk/-/sdk-3.23.1.tgz",
-      "integrity": "sha512-QNLbynCb0qoowNwLhWF38Diox2ZQXa4wy8jlfGd8odJ7aLh04o10OwguL5t4IDVqteHCEW669Is6JmL81OXoyw==",
+      "version": "4.0.0-solana.8",
+      "resolved": "https://registry.npmjs.org/@ar.io/sdk/-/sdk-4.0.0-solana.8.tgz",
+      "integrity": "sha512-+xusf3K9qhHsALPxqpc7HeivQ6dNdFp48Sd/E7HzmnfFH/wPiKASC2z135yUV3B2SJAmO4/SqIvoEnj8APppcQ==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@ar.io/solana-contracts": "0.1.0-devnet.0",
+        "@ardrive/turbo-sdk": "^1.19.0",
         "@dha-team/arbundles": "^1.0.1",
         "@permaweb/aoconnect": "0.0.68",
+        "@solana-program/compute-budget": "^0.15.0",
+        "@solana-program/token": "^0.13.0",
+        "@solana/kit": "^6.8.0",
         "arweave": "1.15.5",
         "axios": "^1.13.2",
+        "bs58": "^6.0.0",
         "commander": "^12.1.0",
         "eventemitter3": "^5.0.1",
         "prompts": "^2.4.2"
@@ -274,6 +281,985 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@ar.io/solana-contracts": {
+      "version": "0.1.0-devnet.0",
+      "resolved": "https://registry.npmjs.org/@ar.io/solana-contracts/-/solana-contracts-0.1.0-devnet.0.tgz",
+      "integrity": "sha512-MzdoB2lBHWNqGRi5Ki7a8legTv8YuoymwuahPSQr6lk75UMr7dMz5VWF2ypXLv2GJZODz69ChNSd/eTP7X4n8g==",
+      "hasInstallScript": true,
+      "license": "AGPL-3.0-or-later",
+      "peerDependencies": {
+        "@solana/kit": ">=6 <7"
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana-program/compute-budget": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/compute-budget/-/compute-budget-0.15.0.tgz",
+      "integrity": "sha512-toejNdIkzpUTqLSIzP0Nofr/EFel8QpPWuTtIKzfCcjn+mXpkThHxPJaNesk251rSTiWaxDZ3WxG7RxYwTWTqA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^6.3.0"
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana-program/system": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/system/-/system-0.12.0.tgz",
+      "integrity": "sha512-ZnAAWeGVMWNtJhw3GdifI2HnhZ0A0H0qs8tBkcFvxp/8wIavvO+GOM4Jd0N22u2+Lni2zcwvcrxrsxj6Mjphng==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^6.1.0"
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana-program/token": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.13.0.tgz",
+      "integrity": "sha512-/Apjrd5lwOJGrPB0J5Rv7EBeclvyEBQPAGA85Scm7wBH+GpkbdLDM9uK3TNg8jjFKyWQYai/JtPHbrx7VgFLSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana-program/system": "^0.12.0"
+      },
+      "peerDependencies": {
+        "@solana/kit": "^6.5.0"
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/accounts": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-6.9.0.tgz",
+      "integrity": "sha512-g36AJreJrgf9AAjOfbdFHEFUTymBgzbWHoEDElZ+fDKvqBINDiUVKzDApwc7C7kGPMFqQBaoEHnQRxf2IqfKZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/rpc-spec": "6.9.0",
+        "@solana/rpc-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/addresses": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.9.0.tgz",
+      "integrity": "sha512-tWnG2L6lo/ZhcMT019F3myDsH87MM8EZbTO0cgwgvVPlEdIGblROFF3tGVrb7FVCOlbPI0ONCFyPbnrmR58LsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/assertions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.9.0.tgz",
+      "integrity": "sha512-FjWWD6e0in+HFsHMvU2zKCbyPfKtDW6iGXZZ9+Qg1QUYpO1AEObsya3F7hb9RkZKUueK4WwWAQnIuvEUp3A1uA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/codecs": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-6.9.0.tgz",
+      "integrity": "sha512-oWOybKa1PTGI1D/FyrvGKralADM1jmVZC2AtgEo+4JTKG0+i1p9ZbwNY2UcJqdYsDMDaGHAx0LMAid9LDCxXTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/fixed-points": "6.9.0",
+        "@solana/options": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/codecs-core": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
+      "integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/codecs-data-structures": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.9.0.tgz",
+      "integrity": "sha512-f7GYtiHafvJDhqiwzUUSr/6AYSK4DCw6quPmA80NZGtkNiFa+g6LoJy2wbC0wp2dxvCwNpxf6x3ILCYRutAvvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/codecs-numbers": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.9.0.tgz",
+      "integrity": "sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/codecs-strings": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.9.0.tgz",
+      "integrity": "sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/errors": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
+      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/errors/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/fast-stable-stringify": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-6.9.0.tgz",
+      "integrity": "sha512-l14zGVsURbT5Aox/kLFQywqV4VaE9/j3h2EvCu9oULVPMwzQB6yezJb1/KyiDwhm/RscooPd0gFQFIKEGQbayw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/functional": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.9.0.tgz",
+      "integrity": "sha512-sgNHOaIjETZZuziZdlwPsU5EjBVj5M0dUbwrSQTTNZe0SxX3pQ1QFVcs5KyvdS7AQcpBVdLjx4CfQjdKXk52GA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/instruction-plans": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-6.9.0.tgz",
+      "integrity": "sha512-SxTSOetEKD+WPzvDuYRsP1+KkwUp8KqL1n7oFx9ThxjyfEY0ly0i9KdbvX5yYVDOA2TSwrltgdu14y/Pf6y3Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/promises": "6.9.0",
+        "@solana/transaction-messages": "6.9.0",
+        "@solana/transactions": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/instructions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-6.9.0.tgz",
+      "integrity": "sha512-LZfJx3bGdUSbGaswoOEPHygticqkCg3TusRczPJXyCmKhoQzPCcGQQ99qMzP7Wg8pEV5tWA5t7tycf8E237ydg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/keys": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.9.0.tgz",
+      "integrity": "sha512-1g2QARiqSjNqT0EIqLDLQ5vRm7hCsbqgFwFAp5GsMV/8BTYT8s1Ct2wLHDZiJ4eAX6beTHVf8LbOBfVejtn3oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/promises": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/kit": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-6.9.0.tgz",
+      "integrity": "sha512-k7BRz7Akfv8wiRtlCR/xUyDLfuMfYMelMR1+AC5KgwaRRJReDF0BucMLNN1In7WoI+KuWwr1OKv4na/oKpyeAQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/accounts": "6.9.0",
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/instruction-plans": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/offchain-messages": "6.9.0",
+        "@solana/plugin-core": "6.9.0",
+        "@solana/plugin-interfaces": "6.9.0",
+        "@solana/program-client-core": "6.9.0",
+        "@solana/programs": "6.9.0",
+        "@solana/rpc": "6.9.0",
+        "@solana/rpc-api": "6.9.0",
+        "@solana/rpc-parsed-types": "6.9.0",
+        "@solana/rpc-spec-types": "6.9.0",
+        "@solana/rpc-subscriptions": "6.9.0",
+        "@solana/rpc-types": "6.9.0",
+        "@solana/signers": "6.9.0",
+        "@solana/subscribable": "6.9.0",
+        "@solana/sysvars": "6.9.0",
+        "@solana/transaction-confirmation": "6.9.0",
+        "@solana/transaction-messages": "6.9.0",
+        "@solana/transactions": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/nominal-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.9.0.tgz",
+      "integrity": "sha512-ouhrnY7a6nsLXRGcariwcmHDdXroCNqOuzwtdjKt2c8e8Drwao9yxPH2VoViNgpq8IGNJeQMEI1TVnoJZRn0gw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/offchain-messages": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-6.9.0.tgz",
+      "integrity": "sha512-qK3tqRPb+E0kmTz5qFXZbEdF4pyzfOWRZjyVESHVGemDDeGzZ1SV3zAxcA6HBCnv4wCBnlyaDPw8t+5sryNMAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/options": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-6.9.0.tgz",
+      "integrity": "sha512-H5ZRWNzzLMwHU/fRU9aVx+3TaMN4gDNCUYxsZxq0h7mqiwxFy6mpy95xPsfdldthCHDYtYnUTxe2sBatGbNHig==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/plugin-core": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-6.9.0.tgz",
+      "integrity": "sha512-KslLSnzY8zbGZibEBVMVUm2ZS8T2xf+cut7F65VjWPoWNAxU+p7933wsMz/az6CF7b65RI7iU3HhCr5/5QF50w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/programs": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-6.9.0.tgz",
+      "integrity": "sha512-L9LAnQtfFFcCDLcbbnxhUtgAmu/kS4aRmrVncdnX5CFyQshlpo0/Qhrq3UA7vnhute4gjYV4pFT+64onH5qGEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/promises": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-6.9.0.tgz",
+      "integrity": "sha512-227PlXRi6KZX4ODYTkJitr9InSa79NTquI72slay4gzxO9VmMepgvYdMAX6kawdN5pt+VzaklKhNhWXk50Pi9g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/rpc": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-6.9.0.tgz",
+      "integrity": "sha512-ny1Kt20+oq3xZErNA56+Magmb2JKYfQgHwZTsBmHKVl/9mBpv1y1+ygV+KNiiX/wWXWstLbdIo1jgPwZPbU2Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.9.0",
+        "@solana/fast-stable-stringify": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/rpc-api": "6.9.0",
+        "@solana/rpc-spec": "6.9.0",
+        "@solana/rpc-spec-types": "6.9.0",
+        "@solana/rpc-transformers": "6.9.0",
+        "@solana/rpc-transport-http": "6.9.0",
+        "@solana/rpc-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/rpc-api": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-6.9.0.tgz",
+      "integrity": "sha512-3KhXS6A1ie6GqTywW/KEMSXJ1VJEU66fxjhuiiqPILuJstP7kex3ycr3H6DirKydUsy6gaKaPN43rE+LfyS7OA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/rpc-parsed-types": "6.9.0",
+        "@solana/rpc-spec": "6.9.0",
+        "@solana/rpc-transformers": "6.9.0",
+        "@solana/rpc-types": "6.9.0",
+        "@solana/transaction-messages": "6.9.0",
+        "@solana/transactions": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/rpc-parsed-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-6.9.0.tgz",
+      "integrity": "sha512-6ThH8izY+DWDyrVOOlS40vTcFjwjCinjfqnId7zhRk8OxhkfHQ/iEj+OnGwD4Yhe8pGdVa7GNVYlrQgQgzQ3eQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/rpc-spec": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-6.9.0.tgz",
+      "integrity": "sha512-3yHRoChc0IpsJbUq0/94l+ar3t9U3Ax58W0HON7eyYe7zFP10UAxpkHn7DPch9DeALyuGph8kVnvl+kXRgJlGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.9.0",
+        "@solana/rpc-spec-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/rpc-spec-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-6.9.0.tgz",
+      "integrity": "sha512-A4fY1JRrcKqX3EfttO4Q8L97nGPqdjfekAV0eDyxN5nu9ngf5p7GKenkl7AYDoHLNr6ZX/C96cRADxXjsRJ0iA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/rpc-subscriptions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-6.9.0.tgz",
+      "integrity": "sha512-IMctZQaMxzvRACQ6ooW98lP+7tVoUJnRgOZtkAdzgBizldQAYPIKd3MulP0jbQPCMfdPsa2Hs0NBcUwfgonq3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.9.0",
+        "@solana/fast-stable-stringify": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/promises": "6.9.0",
+        "@solana/rpc-spec-types": "6.9.0",
+        "@solana/rpc-subscriptions-api": "6.9.0",
+        "@solana/rpc-subscriptions-channel-websocket": "6.9.0",
+        "@solana/rpc-subscriptions-spec": "6.9.0",
+        "@solana/rpc-transformers": "6.9.0",
+        "@solana/rpc-types": "6.9.0",
+        "@solana/subscribable": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/rpc-subscriptions-api": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-6.9.0.tgz",
+      "integrity": "sha512-UA/rPQeNx6zQMUFcS8PPPuB4vzUOtSzIY/igMH0DRoP020NyES2GguIb7Zo7sqDNi4n0gkQRhoW4dPVotcNKdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/rpc-subscriptions-spec": "6.9.0",
+        "@solana/rpc-transformers": "6.9.0",
+        "@solana/rpc-types": "6.9.0",
+        "@solana/transaction-messages": "6.9.0",
+        "@solana/transactions": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-6.9.0.tgz",
+      "integrity": "sha512-kT8Yne9HjJD2gooaOFNSyKrvaIfOy2GR0Ymv8OfecBCwFStdz+SPo5eYXq8ZWoZbr5E/MMpHgqsHBanqa2Ffyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/rpc-subscriptions-spec": "6.9.0",
+        "@solana/subscribable": "6.9.0",
+        "ws": "^8.19.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-6.9.0.tgz",
+      "integrity": "sha512-DbaG67s99vRZQxFMK80UQ7DEKkRJK6JEZeYg/U5UttD6n7ax/vct7qopxGnrt4RCkaaac2fU8Sr+fcnvWQweUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.9.0",
+        "@solana/promises": "6.9.0",
+        "@solana/rpc-spec-types": "6.9.0",
+        "@solana/subscribable": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/rpc-transformers": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-6.9.0.tgz",
+      "integrity": "sha512-dg4LK2wEBpaY+KRk/SJIkYvrvjdsc1AwD4bkmGY4Fp7EwVlvwBQShAQn78Qi4IP0WQ/0n9ncFyUxgcB1Y01ZuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/rpc-spec-types": "6.9.0",
+        "@solana/rpc-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/rpc-transport-http": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-6.9.0.tgz",
+      "integrity": "sha512-4gy30fWJcS6jrcXCoP/optFpGJ/gD9xdkE8wDbe1Ys/Y+e4XjyBt45xtTnbdmMdukvdRX+oXS3zgUIYoagpNzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.9.0",
+        "@solana/rpc-spec": "6.9.0",
+        "@solana/rpc-spec-types": "6.9.0",
+        "undici-types": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/rpc-types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.9.0.tgz",
+      "integrity": "sha512-iFhPzZK3qiQ1lhfNTNBTI7BIs5PfWZSgRLD3enKm8ZAQggzvUklfO3KPh47jVsc/Jsr1UGPH8M3o3m17qjO1Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/fixed-points": "6.9.0",
+        "@solana/nominal-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/signers": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-6.9.0.tgz",
+      "integrity": "sha512-x7WyoRm9IORMqeSqNivZgyY+RERPkmqWxpINPD13kUH+oaZzonORIgxk2Lz+u5iPRXiJPkdRPrQ4FoFWv8i6kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/offchain-messages": "6.9.0",
+        "@solana/transaction-messages": "6.9.0",
+        "@solana/transactions": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/subscribable": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-6.9.0.tgz",
+      "integrity": "sha512-YV0/BrJNfepf10CTfLwD7kRY1kkELDHd+BbHJZhBeiuiXTY3xQTvvx1RFs3NtfFCcTHG25Uh8NpRacQJnxSSIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/sysvars": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-6.9.0.tgz",
+      "integrity": "sha512-e0e+QKr/th9t/O2N1oUoJmcodLghzAtWKUlGb1zyYub0/WJrPImnKqJqp/gDP4tK98mJxopPMcprCeHk4B+TQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/rpc-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/transaction-confirmation": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-6.9.0.tgz",
+      "integrity": "sha512-fzYCOih7hhtBzzNSkAnxMjeFeQ8U7e27k9i0RsgQc3/e3OCynF5HoIVNhhqZbwfIBKiaD4ginJR6slRnfqO32Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/promises": "6.9.0",
+        "@solana/rpc": "6.9.0",
+        "@solana/rpc-subscriptions": "6.9.0",
+        "@solana/rpc-types": "6.9.0",
+        "@solana/transaction-messages": "6.9.0",
+        "@solana/transactions": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/transaction-messages": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-6.9.0.tgz",
+      "integrity": "sha512-OWpryt0w6SHlwHx12Vd1wvx2QwSGBXAIUEHTCtkctcM3AaZRy5cIl7CAq9iD5PgahUsaOyRLBV0zlCJcC2JrJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/rpc-types": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/@solana/transactions": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-6.9.0.tgz",
+      "integrity": "sha512-uKPzLwHbjwChfVl82he17ntkh02PfgnMMhN7uOAC+VbkIt1O+EEw8sX87gi6kdG/EV+QBDQXm9PLAo5W0tYylw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.9.0",
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-data-structures": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/codecs-strings": "6.9.0",
+        "@solana/errors": "6.9.0",
+        "@solana/functional": "6.9.0",
+        "@solana/instructions": "6.9.0",
+        "@solana/keys": "6.9.0",
+        "@solana/nominal-types": "6.9.0",
+        "@solana/rpc-types": "6.9.0",
+        "@solana/transaction-messages": "6.9.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ar.io/sdk/node_modules/arweave": {
@@ -289,6 +1275,60 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/base-x": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "license": "MIT"
+    },
+    "node_modules/@ar.io/sdk/node_modules/bs58": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^5.0.0"
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@ar.io/sdk/node_modules/undici-types": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.2.0.tgz",
+      "integrity": "sha512-uciYZ5yCmf+QJb18kJw10HjquzM7K0z992vWcI+84KeBpTfXT4hfgfGJ5DQbf/mCBPACofkrjvqgcjZfuujjFA==",
+      "license": "MIT"
+    },
+    "node_modules/@ar.io/sdk/node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ar.io/wayfinder-cli": {
@@ -315,7 +1355,6 @@
       "version": "1.41.2",
       "resolved": "https://registry.npmjs.org/@ardrive/turbo-sdk/-/turbo-sdk-1.41.2.tgz",
       "integrity": "sha512-SQUannhzLzW+YqoYNfJAod5VLuf30vd0JU+VT2wlAL47UMeCgdgBPbXIJG1NzuMmVu5epL5+JSEaCimpSXrvHw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/proto-signing": "^0.33.1",
@@ -348,7 +1387,6 @@
       "version": "0.0.57",
       "resolved": "https://registry.npmjs.org/@permaweb/aoconnect/-/aoconnect-0.0.57.tgz",
       "integrity": "sha512-l1+47cZuQ8pOIMOdRXymcegCmefXjqR8Bc2MY6jIzWv9old/tG6mfCue2W1QviGyhjP3zEVQgr7YofkY2lq35Q==",
-      "dev": true,
       "dependencies": {
         "@permaweb/ao-scheduler-utils": "~0.0.20",
         "buffer": "^6.0.3",
@@ -368,7 +1406,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@solana-program/compute-budget/-/compute-budget-0.11.0.tgz",
       "integrity": "sha512-7f1ePqB/eURkTwTOO9TNIdUXZcyrZoX3Uy2hNo7cXMfNhPFWp9AVgIyRNBc2jf15sdUa9gNpW+PfP2iV8AYAaw==",
-      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "@solana/kit": "^5.0"
@@ -378,7 +1415,6 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.9.0.tgz",
       "integrity": "sha512-vnZxndd4ED4Fc56sw93cWZ2djEeeOFxtaPS8SPf5+a+JZjKA/EnKqzbE1y04FuMhIVrLERQ8uR8H2h72eZzlsA==",
-      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "@solana/kit": "^5.0"
@@ -388,7 +1424,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@solana-program/token-2022/-/token-2022-0.6.1.tgz",
       "integrity": "sha512-Ex02cruDMGfBMvZZCrggVR45vdQQSI/unHVpt/7HPt/IwFYB4eTlXtO8otYZyqV/ce5GqZ8S6uwyRf0zy6fdbA==",
-      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "@solana/kit": "^5.0",
@@ -399,7 +1434,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-5.5.1.tgz",
       "integrity": "sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "5.5.1",
@@ -425,7 +1459,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-5.5.1.tgz",
       "integrity": "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/assertions": "5.5.1",
@@ -450,7 +1483,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-5.5.1.tgz",
       "integrity": "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "5.5.1"
@@ -471,7 +1503,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-5.5.1.tgz",
       "integrity": "sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "5.5.1",
@@ -496,7 +1527,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-5.5.1.tgz",
       "integrity": "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "5.5.1"
@@ -517,7 +1547,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-5.5.1.tgz",
       "integrity": "sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "5.5.1",
@@ -540,7 +1569,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-5.5.1.tgz",
       "integrity": "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "5.5.1",
@@ -562,7 +1590,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-5.5.1.tgz",
       "integrity": "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "5.5.1",
@@ -589,7 +1616,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-5.5.1.tgz",
       "integrity": "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "5.6.2",
@@ -614,7 +1640,6 @@
       "version": "14.0.2",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
       "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -624,7 +1649,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-5.5.1.tgz",
       "integrity": "sha512-Ni7s2FN33zTzhTFgRjEbOVFO+UAmK8qi3Iu0/GRFYK4jN696OjKHnboSQH/EacQ+yGqS54bfxf409wU5dsLLCw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -642,7 +1666,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-5.5.1.tgz",
       "integrity": "sha512-tTHoJcEQq3gQx5qsdsDJ0LEJeFzwNpXD80xApW9o/PPoCNimI3SALkZl+zNW8VnxRrV3l3yYvfHWBKe/X3WG3w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -660,7 +1683,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-5.5.1.tgz",
       "integrity": "sha512-h0G1CG6S+gUUSt0eo6rOtsaXRBwCq1+Js2a+Ps9Bzk9q7YHNFA75/X0NWugWLgC92waRp66hrjMTiYYnLBoWOQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "5.5.1",
@@ -682,7 +1704,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-5.5.1.tgz",
       "integrity": "sha512-KRD61cL7CRL+b4r/eB9dEoVxIf/2EJ1Pm1DmRYhtSUAJD2dJ5Xw8QFuehobOGm9URqQ7gaQl+Fkc1qvDlsWqKg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/assertions": "5.5.1",
@@ -707,8 +1728,8 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-5.5.1.tgz",
       "integrity": "sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/accounts": "5.5.1",
         "@solana/addresses": "5.5.1",
@@ -749,7 +1770,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-5.5.1.tgz",
       "integrity": "sha512-I1ImR+kfrLFxN5z22UDiTWLdRZeKtU0J/pkWkO8qm/8WxveiwdIv4hooi8pb6JnlR4mSrWhq0pCIOxDYrL9GIQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -767,7 +1787,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/options/-/options-5.5.1.tgz",
       "integrity": "sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "5.5.1",
@@ -792,7 +1811,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-5.5.1.tgz",
       "integrity": "sha512-7U9kn0Jsx1NuBLn5HRTFYh78MV4XN145Yc3WP/q5BlqAVNlMoU9coG5IUTJIG847TUqC1lRto3Dnpwm6T4YRpA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "5.5.1",
@@ -814,7 +1832,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-5.5.1.tgz",
       "integrity": "sha512-T9lfuUYkGykJmppEcssNiCf6yiYQxJkhiLPP+pyAc2z84/7r3UVIb2tNJk4A9sucS66pzJnVHZKcZVGUUp6wzA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -832,7 +1849,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-5.5.1.tgz",
       "integrity": "sha512-ku8zTUMrkCWci66PRIBC+1mXepEnZH/q1f3ck0kJZ95a06bOTl5KU7HeXWtskkyefzARJ5zvCs54AD5nxjQJ+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "5.5.1",
@@ -861,7 +1877,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-5.5.1.tgz",
       "integrity": "sha512-XWOQQPhKl06Vj0xi3RYHAc6oEQd8B82okYJ04K7N0Vvy3J4PN2cxeK7klwkjgavdcN9EVkYCChm2ADAtnztKnA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "5.5.1",
@@ -892,7 +1907,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-5.5.1.tgz",
       "integrity": "sha512-HEi3G2nZqGEsa3vX6U0FrXLaqnUCg4SKIUrOe8CezD+cSFbRTOn3rCLrUmJrhVyXlHoQVaRO9mmeovk31jWxJg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -910,7 +1924,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-5.5.1.tgz",
       "integrity": "sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "5.5.1",
@@ -932,7 +1945,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-5.5.1.tgz",
       "integrity": "sha512-6OFKtRpIEJQs8Jb2C4OO8KyP2h2Hy1MFhatMAoXA+0Ik8S3H+CicIuMZvGZ91mIu/tXicuOOsNNLu3HAkrakrw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -950,7 +1962,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-5.5.1.tgz",
       "integrity": "sha512-CTMy5bt/6mDh4tc6vUJms9EcuZj3xvK0/xq8IQ90rhkpYvate91RjBP+egvjgSayUg9yucU9vNuUpEjz4spM7w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "5.5.1",
@@ -981,7 +1992,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-5.5.1.tgz",
       "integrity": "sha512-5Oi7k+GdeS8xR2ly1iuSFkAv6CZqwG0Z6b1QZKbEgxadE1XGSDrhM2cn59l+bqCozUWCqh4c/A2znU/qQjROlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "5.5.1",
@@ -1008,7 +2018,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-5.5.1.tgz",
       "integrity": "sha512-iq+rGq5fMKP3/mKHPNB6MC8IbVW41KGZg83Us/+LE3AWOTWV1WT20KT2iH1F1ik9roi42COv/TpoZZvhKj45XQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "5.5.1",
@@ -1032,7 +2041,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-5.5.1.tgz",
       "integrity": "sha512-OsWqLCQdcrRJKvHiMmwFhp9noNZ4FARuMkHT5us3ustDLXaxOjF0gfqZLnMkulSLcKt7TGXqMhBV+HCo7z5M8Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "5.5.1",
@@ -1057,7 +2065,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-5.5.1.tgz",
       "integrity": "sha512-yv8GoVSHqEV0kUJEIhkdOVkR2SvJ6yoWC51cJn2rSV7plr6huLGe0JgujCmB7uZhhaLbcbP3zxXxu9sOjsi7Fg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "5.5.1",
@@ -1081,7 +2088,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-5.5.1.tgz",
       "integrity": "sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "5.5.1",
@@ -1107,7 +2113,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-5.5.1.tgz",
       "integrity": "sha512-FY0IVaBT2kCAze55vEieR6hag4coqcuJ31Aw3hqRH7mv6sV8oqwuJmUrx+uFwOp1gwd5OEAzlv6N4hOOple4sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "5.5.1",
@@ -1136,7 +2141,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-5.5.1.tgz",
       "integrity": "sha512-9K0PsynFq0CsmK1CDi5Y2vUIJpCqkgSS5yfDN0eKPgHqEptLEaia09Kaxc90cSZDZU5mKY/zv1NBmB6Aro9zQQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "5.5.1"
@@ -1157,8 +2161,8 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-5.5.1.tgz",
       "integrity": "sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/accounts": "5.5.1",
         "@solana/codecs": "5.5.1",
@@ -1181,7 +2185,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-5.5.1.tgz",
       "integrity": "sha512-j4mKlYPHEyu+OD7MBt3jRoX4ScFgkhZC6H65on4Fux6LMScgivPJlwnKoZMnsgxFgWds0pl+BYzSiALDsXlYtw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "5.5.1",
@@ -1211,7 +2214,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-5.5.1.tgz",
       "integrity": "sha512-aXyhMCEaAp3M/4fP0akwBBQkFPr4pfwoC5CLDq999r/FUwDax2RE/h4Ic7h2Xk+JdcUwsb+rLq85Y52hq84XvQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "5.5.1",
@@ -1240,7 +2242,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-5.5.1.tgz",
       "integrity": "sha512-8hHtDxtqalZ157pnx6p8k10D7J/KY/biLzfgh9R09VNLLY3Fqi7kJvJCr7M2ik3oRll56pxhraAGCC9yIT6eOA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "5.5.1",
@@ -1272,14 +2273,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
       "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ardrive/turbo-sdk/node_modules/bs58": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
       "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "base-x": "^4.0.0"
@@ -1289,7 +2288,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -1302,14 +2300,12 @@
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.25.0.tgz",
       "integrity": "sha512-AXNgS1Byr27fTI+2bsPEkV9CxkT8H6xNyRI68b3TatlZo3RkzlqQBLL+w7SmGPVpokjHbcuNVQUWE7FRTg+LRA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ardrive/turbo-sdk/node_modules/x402": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/x402/-/x402-1.2.0.tgz",
       "integrity": "sha512-cqcB9LNw1e1Kv6wkKyyKvn7wcYBnJ9vd8336M9jZRgLKDcIDt2n3liiSXyzx4HJTv07f9M2OAk5uKhh/LcbKQQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.2.6",
@@ -1331,7 +2327,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/x402-fetch/-/x402-fetch-1.2.0.tgz",
       "integrity": "sha512-CxCgPO4H4/ADZC31gSUCS/CipkUyppzMJRU3jGrEuhO+2k0optszH+kwO0XJ6pVyDprIT6PvGbmNJ4TGKSCAcQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "viem": "^2.21.26",
@@ -2192,6 +3187,7 @@
       "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-5.5.1.tgz",
       "integrity": "sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/accounts": "5.5.1",
         "@solana/addresses": "5.5.1",
@@ -2857,7 +3853,6 @@
       "version": "0.33.1",
       "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.33.1.tgz",
       "integrity": "sha512-WfWiBf2EbIWpwKG9AOcsIIkR717SY+JdlXM/SL/bI66BdrhniAF+/ZNis9Vo9HF6lP2UU5XrSmFA4snAvEgdrg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/crypto": "^0.33.1",
@@ -2871,7 +3866,6 @@
       "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.33.1.tgz",
       "integrity": "sha512-U4kGIj/SNBzlb2FGgA0sMR0MapVgJUg8N+oIAiN5+vl4GZ3aefmoL1RDyTrFS/7HrB+M+MtHsxC0tvEu4ic/zA==",
       "deprecated": "This uses elliptic for cryptographic operations, which contains several security-relevant bugs. To what degree this affects your application is something you need to carefully investigate. See https://github.com/cosmos/cosmjs/issues/1708 for further pointers. Starting with version 0.34.0 the cryptographic library has been replaced. However, private keys might still be at risk.",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/encoding": "^0.33.1",
@@ -2887,7 +3881,6 @@
       "version": "6.6.1",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
       "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
@@ -2903,14 +3896,12 @@
       "version": "4.12.3",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
       "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@cosmjs/encoding": {
       "version": "0.33.1",
       "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.33.1.tgz",
       "integrity": "sha512-nuNxf29fUcQE14+1p//VVQDwd1iau5lhaW/7uMz7V2AH3GJbFJoJVaKvVyZvdFk+Cnu+s3wCqgq4gJkhRCJfKw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -2922,7 +3913,6 @@
       "version": "0.33.1",
       "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.33.1.tgz",
       "integrity": "sha512-T6VtWzecpmuTuMRGZWuBYHsMF/aznWCYUt/cGMWNSz7DBPipVd0w774PKpxXzpEbyt5sr61NiuLXc+Az15S/Cw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/stream": "^0.33.1",
@@ -2933,7 +3923,6 @@
       "version": "0.33.1",
       "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.33.1.tgz",
       "integrity": "sha512-ytGkWdKFCPiiBU5eqjHNd59djPpIsOjbr2CkNjlnI1Zmdj+HDkSoD9MUGpz9/RJvRir5IvsXqdE05x8EtoQkJA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bn.js": "^5.2.0"
@@ -2943,7 +3932,6 @@
       "version": "0.33.1",
       "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.33.1.tgz",
       "integrity": "sha512-Sv4W+MxX+0LVnd+2rU4Fw1HRsmMwSVSYULj7pRkij3wnPwUlTVoJjmKFgKz13ooIlfzPrz/dnNjGp/xnmXChFQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/amino": "^0.33.1",
@@ -2958,7 +3946,6 @@
       "version": "0.33.1",
       "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.33.1.tgz",
       "integrity": "sha512-KzAeorten6Vn20sMiM6NNWfgc7jbyVo4Zmxev1FXa5EaoLCZy48cmT3hJxUJQvJP/lAy8wPGEjZ/u4rmF11x9A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/stream": "^0.33.1",
@@ -2971,7 +3958,6 @@
       "version": "0.33.1",
       "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.33.1.tgz",
       "integrity": "sha512-CnJ1zpSiaZgkvhk+9aTp5IPmgWn2uo+cNEBN8VuD9sD6BA0V4DMjqe251cNFLiMhkGtiE5I/WXFERbLPww3k8g==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/amino": "^0.33.1",
@@ -2988,7 +3974,6 @@
       "version": "0.33.1",
       "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.33.1.tgz",
       "integrity": "sha512-bMUvEENjeQPSTx+YRzVsWT1uFIdHRcf4brsc14SOoRQ/j5rOJM/aHfsf/BmdSAnYbdOQ3CMKj/8nGAQ7xUdn7w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "xstream": "^11.14.0"
@@ -2998,7 +3983,6 @@
       "version": "0.33.1",
       "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.33.1.tgz",
       "integrity": "sha512-22klDFq2MWnf//C8+rZ5/dYatr6jeGT+BmVbutXYfAK9fmODbtFcumyvB6uWaEORWfNukl8YK1OLuaWezoQvxA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/crypto": "^0.33.1",
@@ -3017,7 +4001,6 @@
       "version": "0.33.1",
       "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.33.1.tgz",
       "integrity": "sha512-UnLHDY6KMmC+UXf3Ufyh+onE19xzEXjT4VZ504Acmk4PXxqyvG4cCPprlKUFnGUX7f0z8Or9MAOHXBx41uHBcg==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@dha-team/arbundles": {
@@ -5804,6 +6787,7 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -5893,6 +6877,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6821,6 +7806,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -7314,6 +8300,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -7759,6 +8746,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -8490,7 +9478,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/fixed-points/-/fixed-points-6.9.0.tgz",
       "integrity": "sha512-0K7mbYC4jdAZFlXqXjpNanmEyZxk7K9NtXDLc1zuhGuxwH8J9guvohwdw2V7TQ9bfjCYsprY3Tp2kUVQpECGmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "6.9.0",
@@ -8512,7 +9499,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
       "integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "6.9.0"
@@ -8533,7 +9519,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
       "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "5.6.2",
@@ -8558,7 +9543,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -8571,7 +9555,6 @@
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
       "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -9012,6 +9995,7 @@
       "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-2.3.0.tgz",
       "integrity": "sha512-sb6PgwoW2LjE5oTFu4lhlS/cGt/NB3YrShEyx7JgWFWysfgLdJnhwWThgwy/4HjNsmtMrQGWVls0yVBHcMvlMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/accounts": "2.3.0",
         "@solana/addresses": "2.3.0",
@@ -9337,7 +10321,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/plugin-interfaces/-/plugin-interfaces-6.9.0.tgz",
       "integrity": "sha512-Qj4sk9thkM1UgnFXvWIoezd/CbqpX/2jigLBDsMB5Ed/gmFlkBSTL127LFDSY3OtzBpXl4hROs+Zqv+5xqtguA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "6.9.0",
@@ -9364,7 +10347,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.9.0.tgz",
       "integrity": "sha512-tWnG2L6lo/ZhcMT019F3myDsH87MM8EZbTO0cgwgvVPlEdIGblROFF3tGVrb7FVCOlbPI0ONCFyPbnrmR58LsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/assertions": "6.9.0",
@@ -9389,7 +10371,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.9.0.tgz",
       "integrity": "sha512-FjWWD6e0in+HFsHMvU2zKCbyPfKtDW6iGXZZ9+Qg1QUYpO1AEObsya3F7hb9RkZKUueK4WwWAQnIuvEUp3A1uA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "6.9.0"
@@ -9410,7 +10391,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
       "integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "6.9.0"
@@ -9431,7 +10411,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.9.0.tgz",
       "integrity": "sha512-f7GYtiHafvJDhqiwzUUSr/6AYSK4DCw6quPmA80NZGtkNiFa+g6LoJy2wbC0wp2dxvCwNpxf6x3ILCYRutAvvg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "6.9.0",
@@ -9454,7 +10433,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.9.0.tgz",
       "integrity": "sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "6.9.0",
@@ -9476,7 +10454,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.9.0.tgz",
       "integrity": "sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "6.9.0",
@@ -9503,7 +10480,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
       "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "5.6.2",
@@ -9528,7 +10504,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.9.0.tgz",
       "integrity": "sha512-sgNHOaIjETZZuziZdlwPsU5EjBVj5M0dUbwrSQTTNZe0SxX3pQ1QFVcs5KyvdS7AQcpBVdLjx4CfQjdKXk52GA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -9546,7 +10521,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-6.9.0.tgz",
       "integrity": "sha512-SxTSOetEKD+WPzvDuYRsP1+KkwUp8KqL1n7oFx9ThxjyfEY0ly0i9KdbvX5yYVDOA2TSwrltgdu14y/Pf6y3Cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "6.9.0",
@@ -9572,7 +10546,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-6.9.0.tgz",
       "integrity": "sha512-LZfJx3bGdUSbGaswoOEPHygticqkCg3TusRczPJXyCmKhoQzPCcGQQ99qMzP7Wg8pEV5tWA5t7tycf8E237ydg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "6.9.0",
@@ -9594,7 +10567,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.9.0.tgz",
       "integrity": "sha512-1g2QARiqSjNqT0EIqLDLQ5vRm7hCsbqgFwFAp5GsMV/8BTYT8s1Ct2wLHDZiJ4eAX6beTHVf8LbOBfVejtn3oQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/assertions": "6.9.0",
@@ -9620,7 +10592,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.9.0.tgz",
       "integrity": "sha512-ouhrnY7a6nsLXRGcariwcmHDdXroCNqOuzwtdjKt2c8e8Drwao9yxPH2VoViNgpq8IGNJeQMEI1TVnoJZRn0gw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -9638,7 +10609,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-6.9.0.tgz",
       "integrity": "sha512-qK3tqRPb+E0kmTz5qFXZbEdF4pyzfOWRZjyVESHVGemDDeGzZ1SV3zAxcA6HBCnv4wCBnlyaDPw8t+5sryNMAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "6.9.0",
@@ -9666,7 +10636,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-6.9.0.tgz",
       "integrity": "sha512-227PlXRi6KZX4ODYTkJitr9InSa79NTquI72slay4gzxO9VmMepgvYdMAX6kawdN5pt+VzaklKhNhWXk50Pi9g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -9684,7 +10653,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-6.9.0.tgz",
       "integrity": "sha512-3yHRoChc0IpsJbUq0/94l+ar3t9U3Ax58W0HON7eyYe7zFP10UAxpkHn7DPch9DeALyuGph8kVnvl+kXRgJlGg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "6.9.0",
@@ -9706,7 +10674,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-6.9.0.tgz",
       "integrity": "sha512-A4fY1JRrcKqX3EfttO4Q8L97nGPqdjfekAV0eDyxN5nu9ngf5p7GKenkl7AYDoHLNr6ZX/C96cRADxXjsRJ0iA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -9724,7 +10691,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-6.9.0.tgz",
       "integrity": "sha512-DbaG67s99vRZQxFMK80UQ7DEKkRJK6JEZeYg/U5UttD6n7ax/vct7qopxGnrt4RCkaaac2fU8Sr+fcnvWQweUg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "6.9.0",
@@ -9748,7 +10714,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.9.0.tgz",
       "integrity": "sha512-iFhPzZK3qiQ1lhfNTNBTI7BIs5PfWZSgRLD3enKm8ZAQggzvUklfO3KPh47jVsc/Jsr1UGPH8M3o3m17qjO1Cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "6.9.0",
@@ -9775,7 +10740,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-6.9.0.tgz",
       "integrity": "sha512-x7WyoRm9IORMqeSqNivZgyY+RERPkmqWxpINPD13kUH+oaZzonORIgxk2Lz+u5iPRXiJPkdRPrQ4FoFWv8i6kQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "6.9.0",
@@ -9804,7 +10768,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-6.9.0.tgz",
       "integrity": "sha512-YV0/BrJNfepf10CTfLwD7kRY1kkELDHd+BbHJZhBeiuiXTY3xQTvvx1RFs3NtfFCcTHG25Uh8NpRacQJnxSSIQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "6.9.0"
@@ -9825,7 +10788,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-6.9.0.tgz",
       "integrity": "sha512-OWpryt0w6SHlwHx12Vd1wvx2QwSGBXAIUEHTCtkctcM3AaZRy5cIl7CAq9iD5PgahUsaOyRLBV0zlCJcC2JrJA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "6.9.0",
@@ -9854,7 +10816,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-6.9.0.tgz",
       "integrity": "sha512-uKPzLwHbjwChfVl82he17ntkh02PfgnMMhN7uOAC+VbkIt1O+EEw8sX87gi6kdG/EV+QBDQXm9PLAo5W0tYylw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "6.9.0",
@@ -9886,7 +10847,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -9899,7 +10859,6 @@
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
       "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -9909,7 +10868,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/program-client-core/-/program-client-core-6.9.0.tgz",
       "integrity": "sha512-+iUnsddhs72QoBJoUO+/yHUXoBvYWa1sGCBRJk35zeg8j7ZXEwRkk6eX0VOrUPxhEpQbYJsIOCrIYApNIt8RFw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/accounts": "6.9.0",
@@ -9938,7 +10896,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-6.9.0.tgz",
       "integrity": "sha512-g36AJreJrgf9AAjOfbdFHEFUTymBgzbWHoEDElZ+fDKvqBINDiUVKzDApwc7C7kGPMFqQBaoEHnQRxf2IqfKZQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "6.9.0",
@@ -9964,7 +10921,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.9.0.tgz",
       "integrity": "sha512-tWnG2L6lo/ZhcMT019F3myDsH87MM8EZbTO0cgwgvVPlEdIGblROFF3tGVrb7FVCOlbPI0ONCFyPbnrmR58LsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/assertions": "6.9.0",
@@ -9989,7 +10945,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.9.0.tgz",
       "integrity": "sha512-FjWWD6e0in+HFsHMvU2zKCbyPfKtDW6iGXZZ9+Qg1QUYpO1AEObsya3F7hb9RkZKUueK4WwWAQnIuvEUp3A1uA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "6.9.0"
@@ -10010,7 +10965,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
       "integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "6.9.0"
@@ -10031,7 +10985,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.9.0.tgz",
       "integrity": "sha512-f7GYtiHafvJDhqiwzUUSr/6AYSK4DCw6quPmA80NZGtkNiFa+g6LoJy2wbC0wp2dxvCwNpxf6x3ILCYRutAvvg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "6.9.0",
@@ -10054,7 +11007,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.9.0.tgz",
       "integrity": "sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "6.9.0",
@@ -10076,7 +11028,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.9.0.tgz",
       "integrity": "sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "6.9.0",
@@ -10103,7 +11054,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
       "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "5.6.2",
@@ -10128,7 +11078,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.9.0.tgz",
       "integrity": "sha512-sgNHOaIjETZZuziZdlwPsU5EjBVj5M0dUbwrSQTTNZe0SxX3pQ1QFVcs5KyvdS7AQcpBVdLjx4CfQjdKXk52GA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -10146,7 +11095,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-6.9.0.tgz",
       "integrity": "sha512-SxTSOetEKD+WPzvDuYRsP1+KkwUp8KqL1n7oFx9ThxjyfEY0ly0i9KdbvX5yYVDOA2TSwrltgdu14y/Pf6y3Cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "6.9.0",
@@ -10172,7 +11120,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-6.9.0.tgz",
       "integrity": "sha512-LZfJx3bGdUSbGaswoOEPHygticqkCg3TusRczPJXyCmKhoQzPCcGQQ99qMzP7Wg8pEV5tWA5t7tycf8E237ydg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "6.9.0",
@@ -10194,7 +11141,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.9.0.tgz",
       "integrity": "sha512-1g2QARiqSjNqT0EIqLDLQ5vRm7hCsbqgFwFAp5GsMV/8BTYT8s1Ct2wLHDZiJ4eAX6beTHVf8LbOBfVejtn3oQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/assertions": "6.9.0",
@@ -10220,7 +11166,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.9.0.tgz",
       "integrity": "sha512-ouhrnY7a6nsLXRGcariwcmHDdXroCNqOuzwtdjKt2c8e8Drwao9yxPH2VoViNgpq8IGNJeQMEI1TVnoJZRn0gw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -10238,7 +11183,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-6.9.0.tgz",
       "integrity": "sha512-qK3tqRPb+E0kmTz5qFXZbEdF4pyzfOWRZjyVESHVGemDDeGzZ1SV3zAxcA6HBCnv4wCBnlyaDPw8t+5sryNMAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "6.9.0",
@@ -10266,7 +11210,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-6.9.0.tgz",
       "integrity": "sha512-227PlXRi6KZX4ODYTkJitr9InSa79NTquI72slay4gzxO9VmMepgvYdMAX6kawdN5pt+VzaklKhNhWXk50Pi9g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -10284,7 +11227,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-6.9.0.tgz",
       "integrity": "sha512-3KhXS6A1ie6GqTywW/KEMSXJ1VJEU66fxjhuiiqPILuJstP7kex3ycr3H6DirKydUsy6gaKaPN43rE+LfyS7OA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "6.9.0",
@@ -10315,7 +11257,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-6.9.0.tgz",
       "integrity": "sha512-6ThH8izY+DWDyrVOOlS40vTcFjwjCinjfqnId7zhRk8OxhkfHQ/iEj+OnGwD4Yhe8pGdVa7GNVYlrQgQgzQ3eQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -10333,7 +11274,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-6.9.0.tgz",
       "integrity": "sha512-3yHRoChc0IpsJbUq0/94l+ar3t9U3Ax58W0HON7eyYe7zFP10UAxpkHn7DPch9DeALyuGph8kVnvl+kXRgJlGg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "6.9.0",
@@ -10355,7 +11295,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-6.9.0.tgz",
       "integrity": "sha512-A4fY1JRrcKqX3EfttO4Q8L97nGPqdjfekAV0eDyxN5nu9ngf5p7GKenkl7AYDoHLNr6ZX/C96cRADxXjsRJ0iA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -10373,7 +11312,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-6.9.0.tgz",
       "integrity": "sha512-dg4LK2wEBpaY+KRk/SJIkYvrvjdsc1AwD4bkmGY4Fp7EwVlvwBQShAQn78Qi4IP0WQ/0n9ncFyUxgcB1Y01ZuQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "6.9.0",
@@ -10398,7 +11336,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.9.0.tgz",
       "integrity": "sha512-iFhPzZK3qiQ1lhfNTNBTI7BIs5PfWZSgRLD3enKm8ZAQggzvUklfO3KPh47jVsc/Jsr1UGPH8M3o3m17qjO1Cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "6.9.0",
@@ -10425,7 +11362,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-6.9.0.tgz",
       "integrity": "sha512-x7WyoRm9IORMqeSqNivZgyY+RERPkmqWxpINPD13kUH+oaZzonORIgxk2Lz+u5iPRXiJPkdRPrQ4FoFWv8i6kQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "6.9.0",
@@ -10454,7 +11390,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-6.9.0.tgz",
       "integrity": "sha512-OWpryt0w6SHlwHx12Vd1wvx2QwSGBXAIUEHTCtkctcM3AaZRy5cIl7CAq9iD5PgahUsaOyRLBV0zlCJcC2JrJA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "6.9.0",
@@ -10483,7 +11418,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-6.9.0.tgz",
       "integrity": "sha512-uKPzLwHbjwChfVl82he17ntkh02PfgnMMhN7uOAC+VbkIt1O+EEw8sX87gi6kdG/EV+QBDQXm9PLAo5W0tYylw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "6.9.0",
@@ -10515,7 +11449,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -10528,7 +11461,6 @@
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
       "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -11038,6 +11970,7 @@
       "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-2.3.0.tgz",
       "integrity": "sha512-LvjADZrpZ+CnhlHqfI5cmsRzX9Rpyb1Ox2dMHnbsRNzeKAMhu9w4ZBIaeTdO322zsTr509G1B+k2ABD3whvUBA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/accounts": "2.3.0",
         "@solana/codecs": "2.3.0",
@@ -11128,7 +12061,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@solana/wallet-standard-features/-/wallet-standard-features-1.3.0.tgz",
       "integrity": "sha512-ZhpZtD+4VArf6RPitsVExvgkF+nGghd1rzPjd97GmBximpnt1rsUxMOEyoIEuH3XBxPyNB6Us7ha7RHWQR+abg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@wallet-standard/base": "^1.1.0",
@@ -11175,7 +12107,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
       "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -11186,7 +12117,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.20.tgz",
       "integrity": "sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.20"
       },
@@ -11337,6 +12267,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -11408,6 +12339,7 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -11841,6 +12773,7 @@
       "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-2.22.1.tgz",
       "integrity": "sha512-cG/xwQWsBEcKgRTkQVhH29cbpbs/TdcUJVFXCyri3ZknxhMyGv0YEjTcrNpRgt2SaswL1KrvslSNYKKo+5YEAg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eventemitter3": "5.0.1",
         "mipd": "0.0.7",
@@ -11902,7 +12835,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@wallet-standard/app/-/app-1.1.0.tgz",
       "integrity": "sha512-3CijvrO9utx598kjr45hTbbeeykQrQfKmSnxeWOgU25TOEpvcipD/bYDQWIqUv1Oc6KK4YStokSMu/FBNecGUQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@wallet-standard/base": "^1.1.0"
@@ -11915,7 +12847,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.0.tgz",
       "integrity": "sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16"
@@ -11925,7 +12856,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.1.0.tgz",
       "integrity": "sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@wallet-standard/base": "^1.1.0"
@@ -13045,6 +13975,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -13119,6 +14050,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -13277,6 +14209,7 @@
       "resolved": "https://registry.npmjs.org/arweave/-/arweave-1.15.7.tgz",
       "integrity": "sha512-F+Y4iWU1qea9IsKQ/YNmLsY4DHQVsaJBuhEbFxQn9cfGHOmtXE+bwo14oY8xqymsqSNf/e1PeIfLk7G7qN/hVA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "arconnect": "^0.4.2",
         "asn1.js": "^5.4.1",
@@ -13393,6 +14326,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
       "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -13798,6 +14732,7 @@
       "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -14404,7 +15339,6 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.9.0.tgz",
       "integrity": "sha512-MN/yUe6mkJwHnCFfsNPeCfXVhyxHYW6c/xDUzrSbBycYzw++XvWDMJArXp2pLdgD6FQ8DW79vkPjeNKVrXaHeQ==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/crc-32": {
@@ -14478,6 +15412,7 @@
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
       "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-fetch": "^2.7.0"
       }
@@ -14674,7 +15609,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -14939,6 +15873,7 @@
       "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.17.tgz",
       "integrity": "sha512-TOOURki4G7sD1wDCjj7NfLaXZZ49dFOeEb5y39IXpb8p0hRzVvfvzZHOi5JcT+PpyAbi/Y+lxPb8eTag2WYH8w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ecies/ciphers": "^0.2.5",
         "@noble/ciphers": "^1.3.0",
@@ -15257,6 +16192,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -15734,7 +16670,6 @@
       "version": "6.16.0",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
       "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -15763,14 +16698,12 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
       "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ethers/node_modules/@noble/curves": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
       "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.3.2"
@@ -15783,7 +16716,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
       "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 16"
@@ -15796,7 +16728,6 @@
       "version": "22.7.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
       "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -15806,28 +16737,24 @@
       "version": "4.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
       "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ethers/node_modules/tslib": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/ethers/node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ethers/node_modules/ws": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -15849,7 +16776,8 @@
       "version": "6.4.9",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
       "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
@@ -16364,7 +17292,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-properties": "^1.2.1",
@@ -17393,14 +18320,12 @@
       "version": "0.7.16",
       "resolved": "https://registry.npmjs.org/libsodium-sumo/-/libsodium-sumo-0.7.16.tgz",
       "integrity": "sha512-x6atrz2AdXCJg6G709x9W9TTJRI6/0NcL5dD0l5GGVqNE48UJmDsjO4RUWYTeyXXUpg+NXZ2SHECaZnFRYzwGA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/libsodium-wrappers-sumo": {
       "version": "0.7.16",
       "resolved": "https://registry.npmjs.org/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.7.16.tgz",
       "integrity": "sha512-gR0JEFPeN3831lB9+ogooQk0KH4K5LSMIO5Prd5Q5XYR2wHFtZfPg0eP7t1oJIWq+UIzlU4WVeBxZ97mt28tXw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "libsodium-sumo": "^0.7.16"
@@ -18122,7 +19047,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -19229,6 +20153,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -19294,6 +20219,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -19320,7 +20246,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/readonly-date/-/readonly-date-1.0.0.tgz",
       "integrity": "sha512-tMKIV7hlk0h4mO3JTmmVuIlJVXjKk3Sep9Bf5OH0O+758ruuVkUy2J9SttDLm91IEX/WHlXPSpxMGjPj4beMIQ==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/real-require": {
@@ -19983,6 +20908,7 @@
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
       "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.4.1",
@@ -20350,7 +21276,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-2.0.3.tgz",
       "integrity": "sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
@@ -20375,6 +21300,7 @@
       "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -20589,6 +21515,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -20704,6 +21631,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -20729,7 +21657,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "devOptional": true,
       "license": "Unlicense"
     },
     "node_modules/type-check": {
@@ -20764,6 +21691,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20868,6 +21796,7 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
       "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -20878,6 +21807,7 @@
       "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -20933,6 +21863,7 @@
       "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.13.2.tgz",
       "integrity": "sha512-Qik0o+DSy741TmkqmRfjq+0xpZBXi/Y6+fXZLn0xNF1z/waFMbE3rkivv5Zcf9RrMUp6zswf2J7sbh2KBlba5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "derive-valtio": "0.1.0",
         "proxy-compare": "2.6.0",
@@ -21020,6 +21951,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -21848,6 +22780,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
       "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -21904,7 +22837,6 @@
       "version": "11.14.0",
       "resolved": "https://registry.npmjs.org/xstream/-/xstream-11.14.0.tgz",
       "integrity": "sha512-1bLb+kKKtKPbgTK6i/BaoAn03g47PpFstlbe1BA+y3pNS/LfvcaghS5BFf9+EE1J+KwSQsEpfJvFN5GqFtiNmw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "globalthis": "^1.0.1",
@@ -21995,7 +22927,8 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
       "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/zustand": {
       "version": "5.0.3",
@@ -22058,1063 +22991,6 @@
         }
       }
     },
-    "packages/wayfinder-core/node_modules/@ar.io/sdk": {
-      "version": "4.0.0-solana.8",
-      "resolved": "https://registry.npmjs.org/@ar.io/sdk/-/sdk-4.0.0-solana.8.tgz",
-      "integrity": "sha512-+xusf3K9qhHsALPxqpc7HeivQ6dNdFp48Sd/E7HzmnfFH/wPiKASC2z135yUV3B2SJAmO4/SqIvoEnj8APppcQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ar.io/solana-contracts": "0.1.0-devnet.0",
-        "@ardrive/turbo-sdk": "^1.19.0",
-        "@dha-team/arbundles": "^1.0.1",
-        "@permaweb/aoconnect": "0.0.68",
-        "@solana-program/compute-budget": "^0.15.0",
-        "@solana-program/token": "^0.13.0",
-        "@solana/kit": "^6.8.0",
-        "arweave": "1.15.5",
-        "axios": "^1.13.2",
-        "bs58": "^6.0.0",
-        "commander": "^12.1.0",
-        "eventemitter3": "^5.0.1",
-        "prompts": "^2.4.2"
-      },
-      "bin": {
-        "ar.io": "lib/esm/cli/cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/wayfinder-core/node_modules/@ar.io/solana-contracts": {
-      "version": "0.1.0-devnet.0",
-      "resolved": "https://registry.npmjs.org/@ar.io/solana-contracts/-/solana-contracts-0.1.0-devnet.0.tgz",
-      "integrity": "sha512-MzdoB2lBHWNqGRi5Ki7a8legTv8YuoymwuahPSQr6lk75UMr7dMz5VWF2ypXLv2GJZODz69ChNSd/eTP7X4n8g==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "AGPL-3.0-or-later",
-      "peerDependencies": {
-        "@solana/kit": ">=6 <7"
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana-program/compute-budget": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@solana-program/compute-budget/-/compute-budget-0.15.0.tgz",
-      "integrity": "sha512-toejNdIkzpUTqLSIzP0Nofr/EFel8QpPWuTtIKzfCcjn+mXpkThHxPJaNesk251rSTiWaxDZ3WxG7RxYwTWTqA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@solana/kit": "^6.3.0"
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana-program/system": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@solana-program/system/-/system-0.12.0.tgz",
-      "integrity": "sha512-ZnAAWeGVMWNtJhw3GdifI2HnhZ0A0H0qs8tBkcFvxp/8wIavvO+GOM4Jd0N22u2+Lni2zcwvcrxrsxj6Mjphng==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@solana/kit": "^6.1.0"
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana-program/token": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.13.0.tgz",
-      "integrity": "sha512-/Apjrd5lwOJGrPB0J5Rv7EBeclvyEBQPAGA85Scm7wBH+GpkbdLDM9uK3TNg8jjFKyWQYai/JtPHbrx7VgFLSg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@solana-program/system": "^0.12.0"
-      },
-      "peerDependencies": {
-        "@solana/kit": "^6.5.0"
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/accounts": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-6.9.0.tgz",
-      "integrity": "sha512-g36AJreJrgf9AAjOfbdFHEFUTymBgzbWHoEDElZ+fDKvqBINDiUVKzDApwc7C7kGPMFqQBaoEHnQRxf2IqfKZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/addresses": "6.9.0",
-        "@solana/codecs-core": "6.9.0",
-        "@solana/codecs-strings": "6.9.0",
-        "@solana/errors": "6.9.0",
-        "@solana/rpc-spec": "6.9.0",
-        "@solana/rpc-types": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/addresses": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.9.0.tgz",
-      "integrity": "sha512-tWnG2L6lo/ZhcMT019F3myDsH87MM8EZbTO0cgwgvVPlEdIGblROFF3tGVrb7FVCOlbPI0ONCFyPbnrmR58LsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/assertions": "6.9.0",
-        "@solana/codecs-core": "6.9.0",
-        "@solana/codecs-strings": "6.9.0",
-        "@solana/errors": "6.9.0",
-        "@solana/nominal-types": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/assertions": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.9.0.tgz",
-      "integrity": "sha512-FjWWD6e0in+HFsHMvU2zKCbyPfKtDW6iGXZZ9+Qg1QUYpO1AEObsya3F7hb9RkZKUueK4WwWAQnIuvEUp3A1uA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/errors": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/codecs": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-6.9.0.tgz",
-      "integrity": "sha512-oWOybKa1PTGI1D/FyrvGKralADM1jmVZC2AtgEo+4JTKG0+i1p9ZbwNY2UcJqdYsDMDaGHAx0LMAid9LDCxXTQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/codecs-core": "6.9.0",
-        "@solana/codecs-data-structures": "6.9.0",
-        "@solana/codecs-numbers": "6.9.0",
-        "@solana/codecs-strings": "6.9.0",
-        "@solana/fixed-points": "6.9.0",
-        "@solana/options": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/codecs-core": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
-      "integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/errors": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/codecs-data-structures": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.9.0.tgz",
-      "integrity": "sha512-f7GYtiHafvJDhqiwzUUSr/6AYSK4DCw6quPmA80NZGtkNiFa+g6LoJy2wbC0wp2dxvCwNpxf6x3ILCYRutAvvg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/codecs-core": "6.9.0",
-        "@solana/codecs-numbers": "6.9.0",
-        "@solana/errors": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/codecs-numbers": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.9.0.tgz",
-      "integrity": "sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/codecs-core": "6.9.0",
-        "@solana/errors": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/codecs-strings": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.9.0.tgz",
-      "integrity": "sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/codecs-core": "6.9.0",
-        "@solana/codecs-numbers": "6.9.0",
-        "@solana/errors": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "fastestsmallesttextencoderdecoder": "^1.0.22",
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "fastestsmallesttextencoderdecoder": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/errors": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
-      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "5.6.2",
-        "commander": "14.0.3"
-      },
-      "bin": {
-        "errors": "bin/cli.mjs"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/errors/node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/fast-stable-stringify": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-6.9.0.tgz",
-      "integrity": "sha512-l14zGVsURbT5Aox/kLFQywqV4VaE9/j3h2EvCu9oULVPMwzQB6yezJb1/KyiDwhm/RscooPd0gFQFIKEGQbayw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/functional": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.9.0.tgz",
-      "integrity": "sha512-sgNHOaIjETZZuziZdlwPsU5EjBVj5M0dUbwrSQTTNZe0SxX3pQ1QFVcs5KyvdS7AQcpBVdLjx4CfQjdKXk52GA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/instruction-plans": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-6.9.0.tgz",
-      "integrity": "sha512-SxTSOetEKD+WPzvDuYRsP1+KkwUp8KqL1n7oFx9ThxjyfEY0ly0i9KdbvX5yYVDOA2TSwrltgdu14y/Pf6y3Cg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/errors": "6.9.0",
-        "@solana/instructions": "6.9.0",
-        "@solana/keys": "6.9.0",
-        "@solana/promises": "6.9.0",
-        "@solana/transaction-messages": "6.9.0",
-        "@solana/transactions": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/instructions": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-6.9.0.tgz",
-      "integrity": "sha512-LZfJx3bGdUSbGaswoOEPHygticqkCg3TusRczPJXyCmKhoQzPCcGQQ99qMzP7Wg8pEV5tWA5t7tycf8E237ydg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/codecs-core": "6.9.0",
-        "@solana/errors": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/keys": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.9.0.tgz",
-      "integrity": "sha512-1g2QARiqSjNqT0EIqLDLQ5vRm7hCsbqgFwFAp5GsMV/8BTYT8s1Ct2wLHDZiJ4eAX6beTHVf8LbOBfVejtn3oQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/assertions": "6.9.0",
-        "@solana/codecs-core": "6.9.0",
-        "@solana/codecs-strings": "6.9.0",
-        "@solana/errors": "6.9.0",
-        "@solana/nominal-types": "6.9.0",
-        "@solana/promises": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/kit": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-6.9.0.tgz",
-      "integrity": "sha512-k7BRz7Akfv8wiRtlCR/xUyDLfuMfYMelMR1+AC5KgwaRRJReDF0BucMLNN1In7WoI+KuWwr1OKv4na/oKpyeAQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/accounts": "6.9.0",
-        "@solana/addresses": "6.9.0",
-        "@solana/codecs": "6.9.0",
-        "@solana/errors": "6.9.0",
-        "@solana/functional": "6.9.0",
-        "@solana/instruction-plans": "6.9.0",
-        "@solana/instructions": "6.9.0",
-        "@solana/keys": "6.9.0",
-        "@solana/offchain-messages": "6.9.0",
-        "@solana/plugin-core": "6.9.0",
-        "@solana/plugin-interfaces": "6.9.0",
-        "@solana/program-client-core": "6.9.0",
-        "@solana/programs": "6.9.0",
-        "@solana/rpc": "6.9.0",
-        "@solana/rpc-api": "6.9.0",
-        "@solana/rpc-parsed-types": "6.9.0",
-        "@solana/rpc-spec-types": "6.9.0",
-        "@solana/rpc-subscriptions": "6.9.0",
-        "@solana/rpc-types": "6.9.0",
-        "@solana/signers": "6.9.0",
-        "@solana/subscribable": "6.9.0",
-        "@solana/sysvars": "6.9.0",
-        "@solana/transaction-confirmation": "6.9.0",
-        "@solana/transaction-messages": "6.9.0",
-        "@solana/transactions": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/nominal-types": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.9.0.tgz",
-      "integrity": "sha512-ouhrnY7a6nsLXRGcariwcmHDdXroCNqOuzwtdjKt2c8e8Drwao9yxPH2VoViNgpq8IGNJeQMEI1TVnoJZRn0gw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/offchain-messages": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-6.9.0.tgz",
-      "integrity": "sha512-qK3tqRPb+E0kmTz5qFXZbEdF4pyzfOWRZjyVESHVGemDDeGzZ1SV3zAxcA6HBCnv4wCBnlyaDPw8t+5sryNMAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/addresses": "6.9.0",
-        "@solana/codecs-core": "6.9.0",
-        "@solana/codecs-data-structures": "6.9.0",
-        "@solana/codecs-numbers": "6.9.0",
-        "@solana/codecs-strings": "6.9.0",
-        "@solana/errors": "6.9.0",
-        "@solana/keys": "6.9.0",
-        "@solana/nominal-types": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/options": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/options/-/options-6.9.0.tgz",
-      "integrity": "sha512-H5ZRWNzzLMwHU/fRU9aVx+3TaMN4gDNCUYxsZxq0h7mqiwxFy6mpy95xPsfdldthCHDYtYnUTxe2sBatGbNHig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/codecs-core": "6.9.0",
-        "@solana/codecs-data-structures": "6.9.0",
-        "@solana/codecs-numbers": "6.9.0",
-        "@solana/codecs-strings": "6.9.0",
-        "@solana/errors": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/plugin-core": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-6.9.0.tgz",
-      "integrity": "sha512-KslLSnzY8zbGZibEBVMVUm2ZS8T2xf+cut7F65VjWPoWNAxU+p7933wsMz/az6CF7b65RI7iU3HhCr5/5QF50w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/programs": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-6.9.0.tgz",
-      "integrity": "sha512-L9LAnQtfFFcCDLcbbnxhUtgAmu/kS4aRmrVncdnX5CFyQshlpo0/Qhrq3UA7vnhute4gjYV4pFT+64onH5qGEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/addresses": "6.9.0",
-        "@solana/errors": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/promises": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-6.9.0.tgz",
-      "integrity": "sha512-227PlXRi6KZX4ODYTkJitr9InSa79NTquI72slay4gzxO9VmMepgvYdMAX6kawdN5pt+VzaklKhNhWXk50Pi9g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/rpc": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-6.9.0.tgz",
-      "integrity": "sha512-ny1Kt20+oq3xZErNA56+Magmb2JKYfQgHwZTsBmHKVl/9mBpv1y1+ygV+KNiiX/wWXWstLbdIo1jgPwZPbU2Vg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/errors": "6.9.0",
-        "@solana/fast-stable-stringify": "6.9.0",
-        "@solana/functional": "6.9.0",
-        "@solana/rpc-api": "6.9.0",
-        "@solana/rpc-spec": "6.9.0",
-        "@solana/rpc-spec-types": "6.9.0",
-        "@solana/rpc-transformers": "6.9.0",
-        "@solana/rpc-transport-http": "6.9.0",
-        "@solana/rpc-types": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/rpc-api": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-6.9.0.tgz",
-      "integrity": "sha512-3KhXS6A1ie6GqTywW/KEMSXJ1VJEU66fxjhuiiqPILuJstP7kex3ycr3H6DirKydUsy6gaKaPN43rE+LfyS7OA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/addresses": "6.9.0",
-        "@solana/codecs-core": "6.9.0",
-        "@solana/codecs-strings": "6.9.0",
-        "@solana/errors": "6.9.0",
-        "@solana/keys": "6.9.0",
-        "@solana/rpc-parsed-types": "6.9.0",
-        "@solana/rpc-spec": "6.9.0",
-        "@solana/rpc-transformers": "6.9.0",
-        "@solana/rpc-types": "6.9.0",
-        "@solana/transaction-messages": "6.9.0",
-        "@solana/transactions": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/rpc-parsed-types": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-6.9.0.tgz",
-      "integrity": "sha512-6ThH8izY+DWDyrVOOlS40vTcFjwjCinjfqnId7zhRk8OxhkfHQ/iEj+OnGwD4Yhe8pGdVa7GNVYlrQgQgzQ3eQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/rpc-spec": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-6.9.0.tgz",
-      "integrity": "sha512-3yHRoChc0IpsJbUq0/94l+ar3t9U3Ax58W0HON7eyYe7zFP10UAxpkHn7DPch9DeALyuGph8kVnvl+kXRgJlGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/errors": "6.9.0",
-        "@solana/rpc-spec-types": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/rpc-spec-types": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-6.9.0.tgz",
-      "integrity": "sha512-A4fY1JRrcKqX3EfttO4Q8L97nGPqdjfekAV0eDyxN5nu9ngf5p7GKenkl7AYDoHLNr6ZX/C96cRADxXjsRJ0iA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/rpc-subscriptions": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-6.9.0.tgz",
-      "integrity": "sha512-IMctZQaMxzvRACQ6ooW98lP+7tVoUJnRgOZtkAdzgBizldQAYPIKd3MulP0jbQPCMfdPsa2Hs0NBcUwfgonq3w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/errors": "6.9.0",
-        "@solana/fast-stable-stringify": "6.9.0",
-        "@solana/functional": "6.9.0",
-        "@solana/promises": "6.9.0",
-        "@solana/rpc-spec-types": "6.9.0",
-        "@solana/rpc-subscriptions-api": "6.9.0",
-        "@solana/rpc-subscriptions-channel-websocket": "6.9.0",
-        "@solana/rpc-subscriptions-spec": "6.9.0",
-        "@solana/rpc-transformers": "6.9.0",
-        "@solana/rpc-types": "6.9.0",
-        "@solana/subscribable": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/rpc-subscriptions-api": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-6.9.0.tgz",
-      "integrity": "sha512-UA/rPQeNx6zQMUFcS8PPPuB4vzUOtSzIY/igMH0DRoP020NyES2GguIb7Zo7sqDNi4n0gkQRhoW4dPVotcNKdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/addresses": "6.9.0",
-        "@solana/keys": "6.9.0",
-        "@solana/rpc-subscriptions-spec": "6.9.0",
-        "@solana/rpc-transformers": "6.9.0",
-        "@solana/rpc-types": "6.9.0",
-        "@solana/transaction-messages": "6.9.0",
-        "@solana/transactions": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/rpc-subscriptions-channel-websocket": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-6.9.0.tgz",
-      "integrity": "sha512-kT8Yne9HjJD2gooaOFNSyKrvaIfOy2GR0Ymv8OfecBCwFStdz+SPo5eYXq8ZWoZbr5E/MMpHgqsHBanqa2Ffyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/errors": "6.9.0",
-        "@solana/functional": "6.9.0",
-        "@solana/rpc-subscriptions-spec": "6.9.0",
-        "@solana/subscribable": "6.9.0",
-        "ws": "^8.19.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/rpc-subscriptions-spec": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-6.9.0.tgz",
-      "integrity": "sha512-DbaG67s99vRZQxFMK80UQ7DEKkRJK6JEZeYg/U5UttD6n7ax/vct7qopxGnrt4RCkaaac2fU8Sr+fcnvWQweUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/errors": "6.9.0",
-        "@solana/promises": "6.9.0",
-        "@solana/rpc-spec-types": "6.9.0",
-        "@solana/subscribable": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/rpc-transformers": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-6.9.0.tgz",
-      "integrity": "sha512-dg4LK2wEBpaY+KRk/SJIkYvrvjdsc1AwD4bkmGY4Fp7EwVlvwBQShAQn78Qi4IP0WQ/0n9ncFyUxgcB1Y01ZuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/errors": "6.9.0",
-        "@solana/functional": "6.9.0",
-        "@solana/nominal-types": "6.9.0",
-        "@solana/rpc-spec-types": "6.9.0",
-        "@solana/rpc-types": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/rpc-transport-http": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-6.9.0.tgz",
-      "integrity": "sha512-4gy30fWJcS6jrcXCoP/optFpGJ/gD9xdkE8wDbe1Ys/Y+e4XjyBt45xtTnbdmMdukvdRX+oXS3zgUIYoagpNzQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/errors": "6.9.0",
-        "@solana/rpc-spec": "6.9.0",
-        "@solana/rpc-spec-types": "6.9.0",
-        "undici-types": "^8.2.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/rpc-transport-http/node_modules/undici-types": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.2.0.tgz",
-      "integrity": "sha512-uciYZ5yCmf+QJb18kJw10HjquzM7K0z992vWcI+84KeBpTfXT4hfgfGJ5DQbf/mCBPACofkrjvqgcjZfuujjFA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/wayfinder-core/node_modules/@solana/rpc-types": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.9.0.tgz",
-      "integrity": "sha512-iFhPzZK3qiQ1lhfNTNBTI7BIs5PfWZSgRLD3enKm8ZAQggzvUklfO3KPh47jVsc/Jsr1UGPH8M3o3m17qjO1Cg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/addresses": "6.9.0",
-        "@solana/codecs-core": "6.9.0",
-        "@solana/codecs-numbers": "6.9.0",
-        "@solana/codecs-strings": "6.9.0",
-        "@solana/errors": "6.9.0",
-        "@solana/fixed-points": "6.9.0",
-        "@solana/nominal-types": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/signers": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-6.9.0.tgz",
-      "integrity": "sha512-x7WyoRm9IORMqeSqNivZgyY+RERPkmqWxpINPD13kUH+oaZzonORIgxk2Lz+u5iPRXiJPkdRPrQ4FoFWv8i6kQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/addresses": "6.9.0",
-        "@solana/codecs-core": "6.9.0",
-        "@solana/errors": "6.9.0",
-        "@solana/instructions": "6.9.0",
-        "@solana/keys": "6.9.0",
-        "@solana/nominal-types": "6.9.0",
-        "@solana/offchain-messages": "6.9.0",
-        "@solana/transaction-messages": "6.9.0",
-        "@solana/transactions": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/subscribable": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-6.9.0.tgz",
-      "integrity": "sha512-YV0/BrJNfepf10CTfLwD7kRY1kkELDHd+BbHJZhBeiuiXTY3xQTvvx1RFs3NtfFCcTHG25Uh8NpRacQJnxSSIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/errors": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/sysvars": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-6.9.0.tgz",
-      "integrity": "sha512-e0e+QKr/th9t/O2N1oUoJmcodLghzAtWKUlGb1zyYub0/WJrPImnKqJqp/gDP4tK98mJxopPMcprCeHk4B+TQg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/accounts": "6.9.0",
-        "@solana/codecs-core": "6.9.0",
-        "@solana/codecs-data-structures": "6.9.0",
-        "@solana/codecs-numbers": "6.9.0",
-        "@solana/errors": "6.9.0",
-        "@solana/rpc-types": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/transaction-confirmation": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-6.9.0.tgz",
-      "integrity": "sha512-fzYCOih7hhtBzzNSkAnxMjeFeQ8U7e27k9i0RsgQc3/e3OCynF5HoIVNhhqZbwfIBKiaD4ginJR6slRnfqO32Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/addresses": "6.9.0",
-        "@solana/codecs-strings": "6.9.0",
-        "@solana/errors": "6.9.0",
-        "@solana/keys": "6.9.0",
-        "@solana/promises": "6.9.0",
-        "@solana/rpc": "6.9.0",
-        "@solana/rpc-subscriptions": "6.9.0",
-        "@solana/rpc-types": "6.9.0",
-        "@solana/transaction-messages": "6.9.0",
-        "@solana/transactions": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/transaction-messages": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-6.9.0.tgz",
-      "integrity": "sha512-OWpryt0w6SHlwHx12Vd1wvx2QwSGBXAIUEHTCtkctcM3AaZRy5cIl7CAq9iD5PgahUsaOyRLBV0zlCJcC2JrJA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/addresses": "6.9.0",
-        "@solana/codecs-core": "6.9.0",
-        "@solana/codecs-data-structures": "6.9.0",
-        "@solana/codecs-numbers": "6.9.0",
-        "@solana/errors": "6.9.0",
-        "@solana/functional": "6.9.0",
-        "@solana/instructions": "6.9.0",
-        "@solana/nominal-types": "6.9.0",
-        "@solana/rpc-types": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/wayfinder-core/node_modules/@solana/transactions": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-6.9.0.tgz",
-      "integrity": "sha512-uKPzLwHbjwChfVl82he17ntkh02PfgnMMhN7uOAC+VbkIt1O+EEw8sX87gi6kdG/EV+QBDQXm9PLAo5W0tYylw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solana/addresses": "6.9.0",
-        "@solana/codecs-core": "6.9.0",
-        "@solana/codecs-data-structures": "6.9.0",
-        "@solana/codecs-numbers": "6.9.0",
-        "@solana/codecs-strings": "6.9.0",
-        "@solana/errors": "6.9.0",
-        "@solana/functional": "6.9.0",
-        "@solana/instructions": "6.9.0",
-        "@solana/keys": "6.9.0",
-        "@solana/nominal-types": "6.9.0",
-        "@solana/rpc-types": "6.9.0",
-        "@solana/transaction-messages": "6.9.0"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "packages/wayfinder-core/node_modules/@types/node": {
       "version": "24.10.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.13.tgz",
@@ -23140,66 +23016,14 @@
         "node": ">=18"
       }
     },
-    "packages/wayfinder-core/node_modules/base-x": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
-      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/wayfinder-core/node_modules/bs58": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
-      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^5.0.0"
-      }
-    },
-    "packages/wayfinder-core/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "packages/wayfinder-core/node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "packages/wayfinder-extension": {
       "name": "@ar.io/wayfinder-extension",
       "version": "1.0.23",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ar.io/sdk": "^3.21.0",
+        "@ar.io/sdk": "^4.0.0-solana.8",
         "@ar.io/wayfinder-core": "^1.9.2",
-        "@permaweb/aoconnect": "0.0.69",
+        "@solana/kit": "^2.1.0",
         "p-debounce": "^4.0.0"
       },
       "devDependencies": {
@@ -23213,27 +23037,6 @@
         "vite-plugin-html": "^3.2.2",
         "vite-plugin-node-polyfills": "^0.24.0",
         "vite-plugin-static-copy": "^3.2.0"
-      }
-    },
-    "packages/wayfinder-extension/node_modules/@permaweb/aoconnect": {
-      "version": "0.0.69",
-      "resolved": "https://registry.npmjs.org/@permaweb/aoconnect/-/aoconnect-0.0.69.tgz",
-      "integrity": "sha512-JHGTHeP3zO1ZAuONBGRFHLsMV2Ba3hFkspyYMjhHmNaxXISpYOFX/L2/G8eBd9WIcTBmUdGVL19xPRnRtdyaNw==",
-      "dependencies": {
-        "@permaweb/ao-scheduler-utils": "~0.0.25",
-        "@permaweb/protocol-tag-utils": "~0.0.2",
-        "base64url": "^3.0.1",
-        "buffer": "^6.0.3",
-        "debug": "^4.4.0",
-        "http-message-signatures": "^1.0.4",
-        "hyper-async": "^1.1.2",
-        "mnemonist": "^0.39.8",
-        "ramda": "^0.30.1",
-        "warp-arbundles": "^1.0.4",
-        "zod": "^3.24.1"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "packages/wayfinder-extension/node_modules/@rollup/pluginutils": {
@@ -23254,6 +23057,7 @@
       "version": "20.19.19",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -23332,6 +23136,7 @@
       "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -23447,6 +23252,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/packages/wayfinder-extension/README.md
+++ b/packages/wayfinder-extension/README.md
@@ -84,8 +84,9 @@ Click the settings icon in the popup to access:
 #### Network Configuration
 - **Gateway Registry Sync**: Manually refresh the gateway list from AR.IO network
 - **ENS Resolution**: Enable/disable Ethereum Name Service support
-- **Process ID**: Configure custom AR.IO process ID (advanced)
-- **AO CU URL**: Set custom AO Compute Unit URL (advanced)
+- **Network**: Select an AR.IO Solana network preset (Devnet, or Custom). Mainnet is reserved for when AR.IO Solana mainnet is deployed.
+- **Solana RPC URL**: Endpoint for Solana JSON-RPC calls (editable only in Custom mode)
+- **Advanced — AR.IO Program IDs**: Override the per-program Solana addresses (core / GAR / ArNS / ANT) when running against localnet or a custom deployment (editable only in Custom mode)
 
 #### Performance Settings
 - **Gateway Cache TTL**: Set how long to cache gateway information

--- a/packages/wayfinder-extension/package.json
+++ b/packages/wayfinder-extension/package.json
@@ -34,9 +34,9 @@
     "format:check": "biome format --config-path=../../biome.json"
   },
   "dependencies": {
-    "@ar.io/sdk": "^3.21.0",
+    "@ar.io/sdk": "^4.0.0-solana.8",
     "@ar.io/wayfinder-core": "^1.9.2",
-    "@permaweb/aoconnect": "0.0.69",
+    "@solana/kit": "^2.1.0",
     "p-debounce": "^4.0.0"
   }
 }

--- a/packages/wayfinder-extension/src/background.ts
+++ b/packages/wayfinder-extension/src/background.ts
@@ -14,12 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { AOProcess, ARIO, AoGateway, WalletAddress } from '@ar.io/sdk/web';
-import { connect } from '@permaweb/aoconnect';
+import { ARIO, AoARIORead, AoGateway, WalletAddress } from '@ar.io/sdk/web';
+import { address, createSolanaRpc } from '@solana/kit';
 import pDebounce from 'p-debounce';
 import { ChromeStorageGatewayProvider } from './adapters/chrome-storage-gateway-provider';
 import { EXTENSION_DEFAULTS } from './config/defaults';
-import { ARIO_MAINNET_PROCESS_ID, DEFAULT_AO_CU_URL } from './constants';
 import { getCachedGatewayRegistry } from './helpers';
 import {
   getRoutableGatewayUrl,
@@ -254,24 +253,83 @@ async function updateDailyStats(
   // Daily stats updated
 }
 
-// Initialize AR.IO SDK
-let arIO = ARIO.init({
-  process: new AOProcess({
-    processId: ARIO_MAINNET_PROCESS_ID,
-    ao: connect({
-      CU_URL: DEFAULT_AO_CU_URL,
-      MODE: 'legacy',
-    }),
-  }),
-});
+/**
+ * Construct a read-only `ARIO` instance from the network configuration
+ * persisted in `chrome.storage.local`, falling back to
+ * `EXTENSION_DEFAULTS` (AR.IO Solana devnet) for any key that isn't set.
+ * Always returns a Solana-backed `AoARIORead`; AO is no longer supported.
+ */
+async function arioFromStorage(): Promise<AoARIORead> {
+  const {
+    rpcUrl = EXTENSION_DEFAULTS.rpcUrl,
+    coreProgramId = EXTENSION_DEFAULTS.coreProgramId,
+    garProgramId = EXTENSION_DEFAULTS.garProgramId,
+    arnsProgramId = EXTENSION_DEFAULTS.arnsProgramId,
+    antProgramId = EXTENSION_DEFAULTS.antProgramId,
+  } = await chrome.storage.local.get([
+    'rpcUrl',
+    'coreProgramId',
+    'garProgramId',
+    'arnsProgramId',
+    'antProgramId',
+  ]);
+
+  return ARIO.init({
+    backend: 'solana',
+    rpc: createSolanaRpc(rpcUrl),
+    coreProgramId: address(coreProgramId),
+    garProgramId: address(garProgramId),
+    arnsProgramId: address(arnsProgramId),
+    antProgramId: address(antProgramId),
+  });
+}
+
+/**
+ * Migrate AO-era storage on upgrade. If the user already used the
+ * extension when it was AO-only (`processId` / `aoCuUrl` present, but no
+ * Solana `network` key yet), silently drop the AO keys, write the
+ * Solana defaults, and invalidate the cached gateway registry so the
+ * next sync repopulates from a Solana gateway source.
+ * No-op on fresh installs and on subsequent runs.
+ */
+async function migrateStorageFromAOEra(): Promise<void> {
+  const { network, processId, aoCuUrl } = await chrome.storage.local.get([
+    'network',
+    'processId',
+    'aoCuUrl',
+  ]);
+
+  // Already migrated.
+  if (network !== undefined) return;
+
+  // Fresh install (no legacy keys, no new keys) — the defaults block
+  // below will populate the new keys.
+  if (processId === undefined && aoCuUrl === undefined) return;
+
+  logger.info(
+    '[migration] AO-era storage detected; resetting to Solana defaults and invalidating cached gateway registry.',
+  );
+
+  await chrome.storage.local.remove([
+    'processId',
+    'aoCuUrl',
+    'localGatewayAddressRegistry',
+    'lastSyncTime',
+    'lastKnownGatewayCount',
+  ]);
+}
+
+// Solana-backed AR.IO read instance; initialized at startup inside the
+// async IIFE below after storage defaults are applied.
+let arIO: AoARIORead | undefined;
 
 // Initialize Chrome storage with defaults
 (async () => {
-  const { dailyStats, processId, aoCuUrl, localGatewayAddressRegistry } =
+  await migrateStorageFromAOEra();
+
+  const { dailyStats, localGatewayAddressRegistry } =
     await chrome.storage.local.get([
       'dailyStats',
-      'processId',
-      'aoCuUrl',
       'localGatewayAddressRegistry',
     ]);
 
@@ -293,26 +351,45 @@ let arIO = ARIO.init({
     dailyStats: existingStats,
   };
 
-  // Set defaults only if not already present
-  if (!processId) updates.processId = EXTENSION_DEFAULTS.processId;
-  if (!aoCuUrl) updates.aoCuUrl = EXTENSION_DEFAULTS.aoCuUrl;
   if (!localGatewayAddressRegistry)
     updates.localGatewayAddressRegistry =
       EXTENSION_DEFAULTS.localGatewayAddressRegistry;
 
   // Only set these if they don't exist in storage
   const {
+    network,
+    rpcUrl,
+    coreProgramId,
+    garProgramId,
+    arnsProgramId,
+    antProgramId,
     routingMethod,
     blacklistedGateways,
     ensResolutionEnabled,
     showVerificationToasts,
   } = await chrome.storage.local.get([
+    'network',
+    'rpcUrl',
+    'coreProgramId',
+    'garProgramId',
+    'arnsProgramId',
+    'antProgramId',
     'routingMethod',
     'blacklistedGateways',
     'ensResolutionEnabled',
     'showVerificationToasts',
   ]);
 
+  if (network === undefined) updates.network = EXTENSION_DEFAULTS.network;
+  if (rpcUrl === undefined) updates.rpcUrl = EXTENSION_DEFAULTS.rpcUrl;
+  if (coreProgramId === undefined)
+    updates.coreProgramId = EXTENSION_DEFAULTS.coreProgramId;
+  if (garProgramId === undefined)
+    updates.garProgramId = EXTENSION_DEFAULTS.garProgramId;
+  if (arnsProgramId === undefined)
+    updates.arnsProgramId = EXTENSION_DEFAULTS.arnsProgramId;
+  if (antProgramId === undefined)
+    updates.antProgramId = EXTENSION_DEFAULTS.antProgramId;
   if (routingMethod === undefined)
     updates.routingMethod = EXTENSION_DEFAULTS.routingMethod;
   if (blacklistedGateways === undefined)
@@ -323,6 +400,8 @@ let arIO = ARIO.init({
     updates.showVerificationToasts = EXTENSION_DEFAULTS.showVerificationToasts;
 
   await chrome.storage.local.set(updates);
+
+  arIO = await arioFromStorage();
 
   debouncedInitializeWayfinder();
 })();
@@ -862,7 +941,15 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.message === 'resetAdvancedSettings') {
     (async () => {
       try {
-        await chrome.storage.local.remove(['processId', 'aoCuUrl']);
+        await chrome.storage.local.set({
+          network: EXTENSION_DEFAULTS.network,
+          rpcUrl: EXTENSION_DEFAULTS.rpcUrl,
+          coreProgramId: EXTENSION_DEFAULTS.coreProgramId,
+          garProgramId: EXTENSION_DEFAULTS.garProgramId,
+          arnsProgramId: EXTENSION_DEFAULTS.arnsProgramId,
+          antProgramId: EXTENSION_DEFAULTS.antProgramId,
+        });
+        arIO = await arioFromStorage();
         resetWayfinderInstance();
         sendResponse({ success: true });
       } catch (error: any) {
@@ -920,34 +1007,11 @@ async function syncGatewayAddressRegistry(): Promise<void> {
   try {
     // Update status to syncing
     await updateSyncStatus('syncing');
-    const { processId, aoCuUrl } = await chrome.storage.local.get([
-      'processId',
-      'aoCuUrl',
-    ]);
 
-    if (!processId || !aoCuUrl) {
-      logger.warn('Process ID or AO CU URL not found, using defaults...');
-      // Use defaults if not set
-      const defaultProcessId = processId || ARIO_MAINNET_PROCESS_ID;
-      const defaultAoCuUrl = aoCuUrl || DEFAULT_AO_CU_URL;
-
-      // Save defaults
-      await chrome.storage.local.set({
-        processId: defaultProcessId,
-        aoCuUrl: defaultAoCuUrl,
-      });
-
-      // Initialize AR.IO with defaults
-      arIO = ARIO.init({
-        process: new AOProcess({
-          processId: defaultProcessId,
-          ao: connect({
-            CU_URL: defaultAoCuUrl,
-            MODE: 'legacy',
-          }),
-        }),
-      });
-    }
+    // Ensure the read instance is initialized — the startup IIFE
+    // normally sets `arIO`, but on cold reloads the sync can fire
+    // before that completes.
+    arIO ??= await arioFromStorage();
 
     // Syncing Gateway Address Registry
     const registry: Record<WalletAddress, AoGateway> = {};
@@ -998,26 +1062,24 @@ async function syncGatewayAddressRegistry(): Promise<void> {
 }
 
 /**
- * Reinitialize AR.IO with updated configuration
+ * Reinitialize the AR.IO read instance after the user changes the
+ * network preset, RPC URL, or program ID overrides in settings.
  */
 async function reinitializeArIO(): Promise<void> {
   try {
-    const { processId, aoCuUrl } = await chrome.storage.local.get([
-      'processId',
-      'aoCuUrl',
-    ]);
-
-    arIO = ARIO.init({
-      process: new AOProcess({
-        processId: processId,
-        ao: connect({ MODE: 'legacy', CU_URL: aoCuUrl }),
-      }),
-    });
-
-    // AR.IO reinitialized
+    arIO = await arioFromStorage();
   } catch (error) {
-    logger.error('Failed to reinitialize AR.IO, using default:', error);
-    arIO = ARIO.init();
+    logger.error('Failed to reinitialize AR.IO from storage:', error);
+    // Fall back to the bundled defaults directly so the extension stays
+    // usable even if the user persisted an invalid RPC URL or program id.
+    arIO = ARIO.init({
+      backend: 'solana',
+      rpc: createSolanaRpc(EXTENSION_DEFAULTS.rpcUrl),
+      coreProgramId: address(EXTENSION_DEFAULTS.coreProgramId),
+      garProgramId: address(EXTENSION_DEFAULTS.garProgramId),
+      arnsProgramId: address(EXTENSION_DEFAULTS.arnsProgramId),
+      antProgramId: address(EXTENSION_DEFAULTS.antProgramId),
+    });
   }
 }
 

--- a/packages/wayfinder-extension/src/background.ts
+++ b/packages/wayfinder-extension/src/background.ts
@@ -794,8 +794,6 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   // Validate message types
   const validMessages = [
     'syncGatewayAddressRegistry',
-    'setArIOProcessId',
-    'setAoCuUrl',
     'resetWayfinder',
     'updateRoutingStrategy',
     'updateVerificationMode',
@@ -857,22 +855,6 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     return true;
   }
 
-  // Set AO CU URL
-  if (request.message === 'setAoCuUrl') {
-    (async () => {
-      try {
-        await reinitializeArIO();
-        await syncGatewayAddressRegistry();
-        resetWayfinderInstance();
-        sendResponse({ success: true });
-      } catch (error: any) {
-        logger.error('Error setting AO CU URL:', error);
-        sendResponse({ error: error?.message || 'Unknown error' });
-      }
-    })();
-    return true;
-  }
-
   // Reset Wayfinder instance (for configuration changes)
   if (request.message === 'resetWayfinder') {
     resetWayfinderInstance();
@@ -918,15 +900,17 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     return true;
   }
 
-  // Handle advanced settings updates
+  // Handle advanced settings updates. The settings page writes the
+  // changed key(s) directly to chrome.storage.local before sending this
+  // message; we just rebuild the ARIO read instance from the new storage
+  // state and reset the wayfinder so it picks up the change.
   if (request.message === 'updateAdvancedSettings') {
     (async () => {
       try {
-        await chrome.storage.local.set(request.settings);
+        await reinitializeArIO();
         resetWayfinderInstance();
-        const changedSettings = Object.keys(request.settings).join(', ');
         logger.info(
-          `[SETTINGS] Wayfinder reinitialized with updated: ${changedSettings}`,
+          '[SETTINGS] ARIO + Wayfinder reinitialized after settings change',
         );
         sendResponse({ success: true });
       } catch (error: any) {

--- a/packages/wayfinder-extension/src/config/defaults.ts
+++ b/packages/wayfinder-extension/src/config/defaults.ts
@@ -15,12 +15,7 @@
  * limitations under the License.
  */
 
-import {
-  ARIO_MAINNET_PROCESS_ID,
-  AR_IO_SOLANA_DEVNET,
-  DEFAULT_AO_CU_URL,
-  FALLBACK_GATEWAY,
-} from '../constants';
+import { AR_IO_SOLANA_DEVNET, FALLBACK_GATEWAY } from '../constants';
 import type { NetworkPreset } from '../types';
 
 /**
@@ -38,9 +33,13 @@ export const SOLANA_NETWORK_DEFAULTS = {
  * Core extension defaults
  */
 export const EXTENSION_DEFAULTS = {
-  // AR.IO Network Configuration
-  processId: ARIO_MAINNET_PROCESS_ID,
-  aoCuUrl: DEFAULT_AO_CU_URL,
+  // AR.IO Network Configuration (Solana)
+  network: 'devnet' satisfies NetworkPreset as NetworkPreset,
+  rpcUrl: AR_IO_SOLANA_DEVNET.rpcUrl,
+  coreProgramId: AR_IO_SOLANA_DEVNET.coreProgramId,
+  garProgramId: AR_IO_SOLANA_DEVNET.garProgramId,
+  arnsProgramId: AR_IO_SOLANA_DEVNET.arnsProgramId,
+  antProgramId: AR_IO_SOLANA_DEVNET.antProgramId,
 
   // Verification Configuration
   showVerificationToasts: false,

--- a/packages/wayfinder-extension/src/constants.ts
+++ b/packages/wayfinder-extension/src/constants.ts
@@ -63,10 +63,7 @@ export const FALLBACK_GATEWAY: AoGatewayWithAddress = {
   gatewayAddress: 'FALLBACK',
 };
 
-export const ARIO_MAINNET_PROCESS_ID =
-  'qNvAoz0TgcH7DMg8BCVn8jF32QH5L6T29VjHxhHqqGE';
 export const GASLESS_ARNS_DNS_EXPIRATION_TIME = 15 * 60 * 1000; // 15 minutes
-export const DEFAULT_AO_CU_URL = 'https://cu.ardrive.io';
 
 /**
  * AR.IO Solana devnet program addresses. Mirrors

--- a/packages/wayfinder-extension/src/gateways.ts
+++ b/packages/wayfinder-extension/src/gateways.ts
@@ -850,10 +850,12 @@ async function runPingTest(gateway: any) {
       try {
         const info = await response.json();
 
-        // Check for required fields based on actual ar-io/info response
+        // Check for required fields based on actual /ar-io/info response.
+        // AR.IO Solana gateways expose `programIds` (object) instead of the
+        // AO-era `processId` (string), so the check moved with the migration.
         const hasWallet = info.wallet && typeof info.wallet === 'string';
-        const hasProcessId =
-          info.processId && typeof info.processId === 'string';
+        const hasProgramIds =
+          info.programIds && typeof info.programIds === 'object';
         const hasRelease = info.release && typeof info.release === 'string';
 
         // Check for manifest support
@@ -864,10 +866,10 @@ async function runPingTest(gateway: any) {
         // Check for ANS-104 configuration
         // const hasANS104Config = 'ans104UnbundleFilter' in info && 'ans104IndexFilter' in info;
 
-        if (hasWallet && hasProcessId && hasRelease && hasManifests) {
+        if (hasWallet && hasProgramIds && hasRelease && hasManifests) {
           healthStatus = 'Healthy';
           healthClass = 'ping-result-value good';
-        } else if (hasWallet && hasProcessId) {
+        } else if (hasWallet && hasProgramIds) {
           healthStatus = 'Partial';
           healthClass = 'ping-result-value warning';
         } else {

--- a/packages/wayfinder-extension/src/settings.html
+++ b/packages/wayfinder-extension/src/settings.html
@@ -226,33 +226,57 @@
           </div>
           
           <div class="network-options">
-            <!-- AR.IO Process ID -->
+            <!-- Network Preset -->
             <div class="network-option">
               <div class="option-header">
                 <div class="option-info">
-                  <h3>AR.IO Process ID</h3>
-                  <p>Process identifier for AR.IO network interactions</p>
+                  <h3>Network</h3>
+                  <p>AR.IO Solana network to connect to. Mainnet is reserved for when AR.IO Solana mainnet is deployed.</p>
                 </div>
               </div>
               <div class="option-input">
-                <input type="text" id="processId" placeholder="Enter AR.IO Process ID..." />
-                <button class="test-button" id="testProcessId" disabled>Test</button>
+                <select id="network">
+                  <option value="mainnet" disabled>AR.IO Solana Mainnet (coming soon)</option>
+                  <option value="devnet">AR.IO Solana Devnet</option>
+                  <option value="custom">Custom</option>
+                </select>
               </div>
             </div>
 
-            <!-- AO Compute Unit URL -->
+            <!-- Solana RPC URL -->
             <div class="network-option">
               <div class="option-header">
                 <div class="option-info">
-                  <h3>AO Compute Unit URL</h3>
-                  <p>URL for AO compute unit interactions</p>
+                  <h3>Solana RPC URL</h3>
+                  <p>Endpoint for Solana JSON-RPC calls. Editable only when Network is set to Custom.</p>
                 </div>
               </div>
               <div class="option-input">
-                <input type="url" id="aoCuUrl" placeholder="Enter AO Compute Unit URL..." />
-                <button class="test-button" id="testAoCuUrl" disabled>Test</button>
+                <input type="url" id="rpcUrl" placeholder="https://..." />
               </div>
             </div>
+
+            <!-- Advanced: AR.IO Program IDs -->
+            <details class="network-option network-option-advanced">
+              <summary><h3>Advanced: AR.IO Program IDs</h3></summary>
+              <p>Per-program Solana addresses. Auto-filled from the selected preset; editable only in Custom mode.</p>
+              <div class="option-input">
+                <label for="coreProgramId">Core</label>
+                <input type="text" id="coreProgramId" placeholder="Solana pubkey..." />
+              </div>
+              <div class="option-input">
+                <label for="garProgramId">GAR (Gateway Address Registry)</label>
+                <input type="text" id="garProgramId" placeholder="Solana pubkey..." />
+              </div>
+              <div class="option-input">
+                <label for="arnsProgramId">ArNS</label>
+                <input type="text" id="arnsProgramId" placeholder="Solana pubkey..." />
+              </div>
+              <div class="option-input">
+                <label for="antProgramId">ANT</label>
+                <input type="text" id="antProgramId" placeholder="Solana pubkey..." />
+              </div>
+            </details>
           </div>
         </section>
 

--- a/packages/wayfinder-extension/src/settings.ts
+++ b/packages/wayfinder-extension/src/settings.ts
@@ -886,13 +886,18 @@ async function resetSettings() {
   }
 
   try {
-    // Clear specific settings
+    // Clear specific settings. Removing the network keys causes the
+    // startup defaults block to repopulate them with the Solana devnet
+    // preset on the next page load.
     await chrome.storage.local.remove([
       'routingMethod',
       'staticGateway',
-      // 'verificationMode', // Removed - no longer used
-      'processId',
-      'aoCuUrl',
+      'network',
+      'rpcUrl',
+      'coreProgramId',
+      'garProgramId',
+      'arnsProgramId',
+      'antProgramId',
       'theme',
     ]);
 

--- a/packages/wayfinder-extension/src/settings.ts
+++ b/packages/wayfinder-extension/src/settings.ts
@@ -18,6 +18,9 @@
 // Import wayfinder-core modules for gateway discovery
 import { ARIO } from '@ar.io/sdk/web';
 import { NetworkGatewaysProvider } from '@ar.io/wayfinder-core';
+import { address, createSolanaRpc } from '@solana/kit';
+import { AR_IO_SOLANA_DEVNET, AR_IO_SOLANA_MAINNET } from './constants';
+import type { NetworkPreset } from './types';
 import { setExtensionVersion } from './utils/version';
 
 // Toast notification system
@@ -145,13 +148,19 @@ function setupEventHandlers() {
     .getElementById('ensResolution')
     ?.addEventListener('change', saveEnsResolution);
 
-  // Advanced settings are now saved automatically on change
-  document
-    .getElementById('processId')
-    ?.addEventListener('change', handleProcessIdChange);
-  document
-    .getElementById('aoCuUrl')
-    ?.addEventListener('change', handleAoCuUrlChange);
+  // Advanced settings are saved automatically on change
+  for (const id of [
+    'network',
+    'rpcUrl',
+    'coreProgramId',
+    'garProgramId',
+    'arnsProgramId',
+    'antProgramId',
+  ]) {
+    document
+      .getElementById(id)
+      ?.addEventListener('change', handleNetworkConfigChange);
+  }
 
   // Performance actions moved to performance.js
 
@@ -229,8 +238,12 @@ async function loadCurrentSettings() {
       'staticGateway',
       'ensResolutionEnabled',
       'theme',
-      'processId',
-      'aoCuUrl',
+      'network',
+      'rpcUrl',
+      'coreProgramId',
+      'garProgramId',
+      'arnsProgramId',
+      'antProgramId',
       'gatewaySortBy',
       'gatewaySortOrder',
       'gatewayCacheTTL',
@@ -301,20 +314,38 @@ async function loadCurrentSettings() {
       applyTheme(theme);
     }
 
-    // Load advanced settings
-    if (settings.processId) {
-      const processIdEl = document.getElementById(
-        'processId',
-      ) as HTMLInputElement;
-      if (processIdEl) {
-        processIdEl.value = settings.processId;
+    // Load advanced (network) settings
+    for (const id of [
+      'network',
+      'rpcUrl',
+      'coreProgramId',
+      'garProgramId',
+      'arnsProgramId',
+      'antProgramId',
+    ] as const) {
+      const el = document.getElementById(id) as
+        | HTMLInputElement
+        | HTMLSelectElement
+        | null;
+      const value = (settings as Record<string, unknown>)[id];
+      if (el && typeof value === 'string') {
+        el.value = value;
       }
     }
-    if (settings.aoCuUrl) {
-      const aoCuUrlEl = document.getElementById('aoCuUrl') as HTMLInputElement;
-      if (aoCuUrlEl) {
-        aoCuUrlEl.value = settings.aoCuUrl;
-      }
+
+    // Lock the RPC URL + program ID inputs unless the user is on the
+    // 'custom' preset; in preset mode they show the preset's values
+    // as read-only.
+    const isCustom = settings.network === 'custom';
+    for (const id of [
+      'rpcUrl',
+      'coreProgramId',
+      'garProgramId',
+      'arnsProgramId',
+      'antProgramId',
+    ]) {
+      const el = document.getElementById(id) as HTMLInputElement | null;
+      if (el) el.disabled = !isCustom;
     }
 
     // Load gateway provider settings
@@ -610,10 +641,34 @@ async function fetchAvailableGateways() {
     return gateways;
   } catch (error) {
     console.error('Error fetching gateways from local registry:', error);
-    // Try to fetch from AR.IO network as fallback
+    // Try to fetch from AR.IO network as fallback. Constructs a
+    // read-only Solana-backed ARIO using the user's currently-configured
+    // RPC + program IDs (falling back to the AR.IO Solana devnet
+    // defaults if anything is missing).
     try {
+      const {
+        rpcUrl = AR_IO_SOLANA_DEVNET.rpcUrl,
+        coreProgramId = AR_IO_SOLANA_DEVNET.coreProgramId,
+        garProgramId = AR_IO_SOLANA_DEVNET.garProgramId,
+        arnsProgramId = AR_IO_SOLANA_DEVNET.arnsProgramId,
+        antProgramId = AR_IO_SOLANA_DEVNET.antProgramId,
+      } = await chrome.storage.local.get([
+        'rpcUrl',
+        'coreProgramId',
+        'garProgramId',
+        'arnsProgramId',
+        'antProgramId',
+      ]);
+
       const networkProvider = new NetworkGatewaysProvider({
-        ario: ARIO.mainnet(),
+        ario: ARIO.init({
+          backend: 'solana',
+          rpc: createSolanaRpc(rpcUrl),
+          coreProgramId: address(coreProgramId),
+          garProgramId: address(garProgramId),
+          arnsProgramId: address(arnsProgramId),
+          antProgramId: address(antProgramId),
+        }),
       });
       const networkGateways = await networkProvider.getGateways();
 
@@ -853,55 +908,78 @@ async function resetSettings() {
   }
 }
 
-async function handleProcessIdChange(event: any) {
-  const processId = event.target.value.trim();
+/**
+ * Single handler for all network-related field changes:
+ * - `network`: preset selector ('mainnet' | 'devnet' | 'custom')
+ * - `rpcUrl`: Solana RPC endpoint
+ * - `coreProgramId` / `garProgramId` / `arnsProgramId` / `antProgramId`:
+ *   per-program AR.IO Solana program IDs (base58)
+ *
+ * Selecting a non-custom preset auto-fills the RPC + program IDs from
+ * the preset definition and disables those inputs in the UI.
+ */
+async function handleNetworkConfigChange(event: Event) {
+  const target = event.target as HTMLInputElement | HTMLSelectElement;
+  const key = target.id as
+    | 'network'
+    | 'rpcUrl'
+    | 'coreProgramId'
+    | 'garProgramId'
+    | 'arnsProgramId'
+    | 'antProgramId';
+  const value = target.value.trim();
 
   try {
-    if (processId) {
-      await chrome.storage.local.set({ processId });
+    if (key === 'network') {
+      const preset = value as NetworkPreset;
+      const presetConfig =
+        preset === 'devnet'
+          ? AR_IO_SOLANA_DEVNET
+          : preset === 'mainnet'
+            ? AR_IO_SOLANA_MAINNET
+            : null;
+
+      if (preset !== 'custom' && presetConfig === null) {
+        showToast(`${preset} is not yet available`, 'warning');
+        // Revert the dropdown back to the previous value.
+        const { network: prev } = await chrome.storage.local.get(['network']);
+        if (prev && target instanceof HTMLSelectElement) target.value = prev;
+        return;
+      }
+
+      const updates: Record<string, string> = { network: preset };
+      if (presetConfig !== null) {
+        Object.assign(updates, presetConfig);
+      }
+      await chrome.storage.local.set(updates);
+
+      // Refresh form values + lock state.
+      await loadCurrentSettings();
     } else {
-      await chrome.storage.local.remove(['processId']);
+      // Per-field edit (only reachable in 'custom' mode; UI guards the
+      // others as `disabled`).
+      if (key === 'rpcUrl') {
+        new URL(value); // validates http(s)://… or throws
+      }
+      // Program IDs: validate as Solana base58 addresses.
+      else if (value.length > 0) {
+        address(value);
+      }
+      if (value) {
+        await chrome.storage.local.set({ [key]: value });
+      } else {
+        await chrome.storage.local.remove([key]);
+      }
     }
 
-    // Notify background script
     await chrome.runtime.sendMessage({
       message: 'updateAdvancedSettings',
-      settings: { processId },
     });
 
-    showToast('Process ID updated', 'success');
-  } catch (error) {
-    console.error('Error updating process ID:', error);
-    showToast('Failed to update process ID', 'error');
-  }
-}
-
-async function handleAoCuUrlChange(event: any) {
-  const aoCuUrl = event.target.value.trim();
-
-  try {
-    if (aoCuUrl) {
-      // Validate URL
-      new URL(aoCuUrl);
-      await chrome.storage.local.set({ aoCuUrl });
-    } else {
-      await chrome.storage.local.remove(['aoCuUrl']);
-    }
-
-    // Notify background script
-    await chrome.runtime.sendMessage({
-      message: 'updateAdvancedSettings',
-      settings: { aoCuUrl },
-    });
-
-    showToast('AO CU URL updated', 'success');
+    showToast(`${key} updated`, 'success');
   } catch (error: any) {
-    console.error('Error updating AO CU URL:', error);
-    if (aoCuUrl && error.message.includes('URL')) {
-      showToast('Invalid URL format', 'error');
-    } else {
-      showToast('Failed to update AO CU URL', 'error');
-    }
+    console.error(`Error updating ${key}:`, error);
+    showToast(`Invalid value for ${key}`, 'error');
   }
 }
 

--- a/packages/wayfinder-extension/vite.config.js
+++ b/packages/wayfinder-extension/vite.config.js
@@ -82,11 +82,7 @@ export default defineConfig({
         // Manual chunks configuration
         manualChunks: {
           // Group SDK and large dependencies together
-          webIndex: [
-            '@ar.io/sdk/web',
-            '@permaweb/aoconnect',
-            '@ar.io/wayfinder-core',
-          ],
+          webIndex: ['@ar.io/sdk/web', '@solana/kit', '@ar.io/wayfinder-core'],
         },
       },
     },


### PR DESCRIPTION
## Summary

BREAKING — wayfinder-extension is now Solana-only. AO support has been removed. This is **PR B of two** for the migration; depends on [#246](https://github.com/ar-io/wayfinder/pull/246) (the additive foundation).

> **Note on base branch:** This PR currently targets `refactor/extension-solana-foundation` so the diff stays clean while PR A is in review. Once PR A merges, GitHub will auto-retarget this PR to `solana`.

## What changed

### Code

- **`src/background.ts`** — drops `AOProcess` + `@permaweb/aoconnect` + AO process constant imports; adds `arioFromStorage()` helper that constructs a read-only Solana `ARIO.init({backend: 'solana', rpc, ...programIds})` from `chrome.storage.local`; rewrites the four `ARIO.init` call sites to use it; adds `migrateStorageFromAOEra()` for the storage schema bump.
- **`src/settings.ts`** — drops `ARIO.mainnet()` fallback in favor of a Solana-backed `ARIO.init` built from current storage; replaces `handleProcessIdChange` + `handleAoCuUrlChange` with a consolidated `handleNetworkConfigChange` covering all six new fields. Validates RPC via `URL()` and program IDs via `@solana/kit`'s `address()`.
- **`src/constants.ts`** — removes `ARIO_MAINNET_PROCESS_ID`, `DEFAULT_AO_CU_URL`.
- **`src/config/defaults.ts`** — drops AO `processId`/`aoCuUrl`; replaces with Solana `network`/`rpcUrl`/4 program IDs.
- **`src/settings.html`** — "AR.IO Process ID" + "AO Compute Unit URL" sections replaced with a Network preset selector, a Solana RPC URL input, and a collapsible "Advanced: AR.IO Program IDs" panel. `mainnet` preset is `<option disabled>` until AR.IO Solana mainnet ships.

### Dependencies

- `@ar.io/sdk`: `^3.21.0` → `^4.0.0-solana.8`
- `@solana/kit`: added at `^2.1.0`
- `@permaweb/aoconnect`: **removed**

### Storage migration

AO-era users had `processId` + `aoCuUrl` in `chrome.storage.local`. On first run after upgrade:

1. `migrateStorageFromAOEra()` detects the legacy keys
2. Removes `processId`, `aoCuUrl`, and the cached `localGatewayAddressRegistry` (AO gateway data is irrelevant on Solana)
3. The startup defaults block writes the new Solana keys (`network: 'devnet'` + devnet RPC + four program IDs)
4. Background re-init connects to AR.IO Solana devnet
5. The next gateway sync repopulates the registry from Solana

User sees the extension keep working with no prompt. One info-level log line is emitted so the migration is visible in devtools.

## Verified locally

- [x] `npm run build -w @ar.io/wayfinder-extension` passes (tsc + vite)
- [x] `biome check` passes
- [x] Bundle size shrinks (vendor chunk: 5.3 MB → 3.8 MB) from dropping the AO compute stack + aoconnect

## Smoke-test checklist (manual; no automated tests exist in this package)

Load `packages/wayfinder-extension/dist/` as an unpacked extension in `chrome://extensions` and:

**Fresh install path:**
- [ ] Popup loads
- [ ] Settings → Network = "AR.IO Solana Devnet" by default
- [ ] Program IDs auto-populated and disabled (preset mode)
- [ ] Click "Sync Gateway Registry" → registry fills from devnet
- [ ] Navigate to `ar://ardrive` → resolves and routes through a devnet gateway

**Upgrade-from-AO path:**
- [ ] Before installing the new build, seed `chrome.storage.local` with `processId: "qNvAoz..."` + `aoCuUrl: "https://cu.ardrive.io"` + a fake `localGatewayAddressRegistry`
- [ ] Install the new build
- [ ] Reload service worker
- [ ] Confirm in devtools: old keys removed, new Solana keys present, `localGatewayAddressRegistry` cleared, one `[migration]` info line logged

**Custom network path:**
- [ ] Switch preset to "Custom" → RPC + program ID inputs become editable
- [ ] Enter an invalid URL → toast: "Invalid value for rpcUrl"
- [ ] Enter an invalid base58 string for a program ID → toast: "Invalid value for ..."
- [ ] Switch back to "Devnet" → fields auto-fill + disable

🤖 Generated with [Claude Code](https://claude.com/claude-code)