### PR TITLE
fix(extension): Solana migration follow-ups (fallback gate + startup robustness + dead code)

### DIFF
--- a/.changeset/extension-solana-followups.md
+++ b/.changeset/extension-solana-followups.md
@@ -1,0 +1,29 @@
+---
+"@ar.io/wayfinder-extension": patch
+---
+
+Follow-up fixes after the Solana migration:
+
+- **Stop falling back to a mainnet gateway when the user is on a
+  non-mainnet network.** `FALLBACK_GATEWAY` is hardcoded to a mainnet
+  gateway (turbo-gateway.com); using it from a devnet or custom-network
+  install would silently serve mainnet content under the user's
+  chosen network. `routing.ts` now reads the `network` preset from
+  storage and only triggers the mainnet fallback when
+  `network === 'mainnet'`. On devnet or custom, the original routing
+  error is propagated instead.
+
+- **Tolerate invalid stored network config on startup.** The IIFE that
+  initializes the read-only `ARIO` instance on service-worker boot
+  now wraps `arioFromStorage()` in a try/catch and falls back to the
+  bundled devnet defaults if the user previously persisted a bad RPC
+  URL or program ID via the custom-network preset. Previously, a
+  single bad value could brick `debouncedInitializeWayfinder()` and
+  leave routing inoperable until manual settings reset.
+
+- **Drop two orphan message-handler allowlist entries**
+  (`resetAdvancedSettings`, `updateVerificationMode`) plus the
+  unreachable `resetAdvancedSettings` handler body. Neither was wired
+  to a UI control after the AO → Solana migration and the latter's
+  responsibilities are covered by the existing
+  `updateAdvancedSettings` flow.

--- a/packages/wayfinder-extension/src/background.ts
+++ b/packages/wayfinder-extension/src/background.ts
@@ -401,7 +401,26 @@ let arIO: AoARIORead | undefined;
 
   await chrome.storage.local.set(updates);
 
-  arIO = await arioFromStorage();
+  // arioFromStorage() can throw if the user previously persisted an
+  // invalid custom RPC URL or program ID (via @solana/kit's address()
+  // assertion). Don't let that block service-worker startup —
+  // syncGatewayAddressRegistry + reinitializeArIO can still recover.
+  try {
+    arIO = await arioFromStorage();
+  } catch (error: any) {
+    logger.error(
+      'Failed to initialize ARIO from stored config; falling back to bundled devnet defaults.',
+      { error: error?.message },
+    );
+    arIO = ARIO.init({
+      backend: 'solana',
+      rpc: createSolanaRpc(EXTENSION_DEFAULTS.rpcUrl),
+      coreProgramId: address(EXTENSION_DEFAULTS.coreProgramId),
+      garProgramId: address(EXTENSION_DEFAULTS.garProgramId),
+      arnsProgramId: address(EXTENSION_DEFAULTS.arnsProgramId),
+      antProgramId: address(EXTENSION_DEFAULTS.antProgramId),
+    });
+  }
 
   debouncedInitializeWayfinder();
 })();
@@ -796,9 +815,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     'syncGatewayAddressRegistry',
     'resetWayfinder',
     'updateRoutingStrategy',
-    'updateVerificationMode',
     'updateAdvancedSettings',
-    'resetAdvancedSettings',
     'updateShowVerificationToasts',
   ];
 
@@ -915,29 +932,6 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         sendResponse({ success: true });
       } catch (error: any) {
         logger.error('Error updating advanced settings:', error);
-        sendResponse({ error: error?.message || 'Unknown error' });
-      }
-    })();
-    return true;
-  }
-
-  // Handle advanced settings reset
-  if (request.message === 'resetAdvancedSettings') {
-    (async () => {
-      try {
-        await chrome.storage.local.set({
-          network: EXTENSION_DEFAULTS.network,
-          rpcUrl: EXTENSION_DEFAULTS.rpcUrl,
-          coreProgramId: EXTENSION_DEFAULTS.coreProgramId,
-          garProgramId: EXTENSION_DEFAULTS.garProgramId,
-          arnsProgramId: EXTENSION_DEFAULTS.arnsProgramId,
-          antProgramId: EXTENSION_DEFAULTS.antProgramId,
-        });
-        arIO = await arioFromStorage();
-        resetWayfinderInstance();
-        sendResponse({ success: true });
-      } catch (error: any) {
-        logger.error('Error resetting advanced settings:', error);
         sendResponse({ error: error?.message || 'Unknown error' });
       }
     })();

--- a/packages/wayfinder-extension/src/routing.ts
+++ b/packages/wayfinder-extension/src/routing.ts
@@ -295,7 +295,20 @@ export async function getRoutableGatewayUrl(arUrl: string): Promise<{
       logger.error('[ROUTING] Non-Error thrown:', error);
     }
 
-    // Try fallback gateway as last resort
+    // Try fallback gateway as last resort — but only on the mainnet
+    // preset. FALLBACK_GATEWAY is hardcoded to a mainnet gateway
+    // (turbo-gateway.com); using it on devnet or a custom network would
+    // silently serve mainnet content as if it were the user's chosen
+    // network. Refuse the fallback in that case and propagate the
+    // original error so the user can resync their gateway registry.
+    const { network } = await chrome.storage.local.get(['network']);
+    if (network !== 'mainnet') {
+      logger.warn(
+        `[ROUTING] Skipping mainnet fallback gateway on network=${network ?? 'unset'}; refusing to cross-contaminate networks.`,
+      );
+      throw new Error(userFriendlyMessage);
+    }
+
     try {
       const fallbackGateway = FALLBACK_GATEWAY;
       const { protocol, fqdn, port } = fallbackGateway.settings;


### PR DESCRIPTION
## Summary

Three categories of cleanup surfaced by a post-merge end-to-end scan of the Solana migration.

### 🔴 Stop cross-network contamination via the mainnet fallback gateway

`FALLBACK_GATEWAY` in `constants.ts` is hardcoded to `turbo-gateway.com` (mainnet). `routing.ts` uses it as a last-resort fallback when normal routing fails. After the migration the extension defaults to AR.IO Solana **devnet**, where the gateway registry is sparsely populated — so the fallback fires often and silently serves **mainnet content under the user's devnet network**.

Fix: the fallback is now gated on `network === 'mainnet'` in `chrome.storage.local`. On devnet or `custom`, the original routing error is propagated instead. The empty-registry condition surfaces to the user rather than being masked.

### 🟠 Startup robustness against bad stored network config

The boot IIFE in `background.ts` called `arIO = await arioFromStorage()` with no try/catch. `arioFromStorage()` invokes `@solana/kit`'s `address()` on each stored program ID — which throws on non-base58 input. A user who previously persisted a bad value via the custom-network preset would crash the IIFE before `debouncedInitializeWayfinder()` ran, leaving routing inoperable until manual reset.

Fix: wrap in try/catch with a fallback to bundled `EXTENSION_DEFAULTS`, mirroring the existing `reinitializeArIO()` catch path.

### 🟡 Dead code

- **`resetAdvancedSettings`** message handler: had Solana-defaults reset logic but no UI button calling it. The startup defaults block + existing `updateAdvancedSettings` flow cover the same surface.
- **`updateVerificationMode`** allowlist entry: pure dead string. No handler exists in the post-migration tree.

Both removed from `validMessages`; the `resetAdvancedSettings` handler body removed too.

## Test plan

- [x] `npm run build -w @ar.io/wayfinder-extension` passes
- [x] `npm run lint:check` (biome + eslint, 121 files) passes
- [ ] **Manual smoke (you):**
  - On devnet: force a routing failure (empty/blacklisted registry) → confirm UI shows error instead of mainnet content
  - Persist a bad program ID in custom mode → reload extension → confirm service worker still boots (logs the fallback warning, lands on bundled devnet defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)