### PR TITLE
docs(core): rewrite README examples from AO mainnet to Solana syntax

### DIFF
--- a/.changeset/wayfinder-core-readme-solana.md
+++ b/.changeset/wayfinder-core-readme-solana.md
@@ -1,0 +1,16 @@
+---
+"@ar.io/wayfinder-core": patch
+---
+
+Docs: update README examples from AO-era `ARIO.mainnet()` syntax to
+SDK 4.x Solana syntax (`ARIO.init({ backend: 'solana', rpc, ...programIds })`).
+
+The package itself is chain-agnostic and works against any SDK
+backend, but the published README only showed AO-mainnet examples,
+which is misleading in the post-Solana-migration ecosystem. The four
+example blocks (Getting Started, NetworkGatewaysProvider reference,
+CompositeGatewaysProvider, CompositeRoutingStrategy) now show AR.IO
+Solana devnet syntax with a note explaining how to drop the
+program-ID overrides for the eventual mainnet deployment.
+
+No code changes; this is docs-only.

--- a/packages/wayfinder-core/README.md
+++ b/packages/wayfinder-core/README.md
@@ -38,11 +38,25 @@ import {
   NetworkGatewaysProvider,
 } from '@ar.io/wayfinder-core';
 import { ARIO } from '@ar.io/sdk';
+import { address, createSolanaRpc } from '@solana/kit';
+
+// AR.IO Solana devnet. When AR.IO Solana mainnet is deployed, drop the
+// program-id overrides (the SDK ships mainnet defaults) and point `rpc`
+// at a mainnet endpoint. wayfinder-core itself is chain-agnostic — the
+// same APIs work against any backend the SDK supports.
+const ario = ARIO.init({
+  backend: 'solana',
+  rpc: createSolanaRpc('https://api.devnet.solana.com'),
+  coreProgramId: address('83CQLP848zzCgnZ4LTq87g6hvxTooNLX7YXXkUUGv5ig'),
+  garProgramId: address('AF8QAEaR4hzsqeUDwEdeTXMYtdyFegTENBdnJro6WVLR'),
+  arnsProgramId: address('2HgSCKYjcapJPdHRKqkLrGXm7kvBmCP45ZyhWEm87oM1'),
+  antProgramId: address('8ZMuXhiK7DorjPUg8RB1rzu7CvsABMk38WDJRbM62y2C'),
+});
 
 const wayfinder = createWayfinderClient({
   routingStrategy: new FastestPingRoutingStrategy({
     gatewaysProvider: new NetworkGatewaysProvider({
-      ario: ARIO.mainnet(),
+      ario,
       sortBy: 'operatorStake',
       sortOrder: 'desc',
       limit: 10,
@@ -176,14 +190,26 @@ Gateway providers supply the list of gateways for routing. **By default, `create
 
 #### NetworkGatewaysProvider
 
-Returns a list of gateways from the ARIO Network based on on-chain [Gateway Address Registry](https://docs.ar.io/learn/gateways/gateway-registry). You can specify on-chain metrics for gateways to prioritize the highest quality gateways. This requires installing the `@ar.io/sdk` package and importing the `ARIO` object.
+Returns a list of gateways from the ARIO Network based on on-chain [Gateway Address Registry](https://docs.ar.io/learn/gateways/gateway-registry). You can specify on-chain metrics for gateways to prioritize the highest quality gateways. Requires `@ar.io/sdk` plus `@solana/kit` for the Solana backend.
 
 ```javascript
 import { NetworkGatewaysProvider } from '@ar.io/wayfinder-core';
 import { ARIO } from '@ar.io/sdk';
+import { address, createSolanaRpc } from '@solana/kit';
+
+// AR.IO Solana devnet — see the Getting Started example above for
+// the mainnet variant once it is deployed.
+const ario = ARIO.init({
+  backend: 'solana',
+  rpc: createSolanaRpc('https://api.devnet.solana.com'),
+  coreProgramId: address('83CQLP848zzCgnZ4LTq87g6hvxTooNLX7YXXkUUGv5ig'),
+  garProgramId: address('AF8QAEaR4hzsqeUDwEdeTXMYtdyFegTENBdnJro6WVLR'),
+  arnsProgramId: address('2HgSCKYjcapJPdHRKqkLrGXm7kvBmCP45ZyhWEm87oM1'),
+  antProgramId: address('8ZMuXhiK7DorjPUg8RB1rzu7CvsABMk38WDJRbM62y2C'),
+});
 
 const gatewayProvider = new NetworkGatewaysProvider({
-  ario: ARIO.mainnet(),
+  ario,
   sortBy: 'operatorStake',
   sortOrder: 'desc',
   limit: 10,
@@ -222,13 +248,23 @@ import {
   TrustedPeersGatewaysProvider,
 } from '@ar.io/wayfinder-core';
 import { ARIO } from '@ar.io/sdk';
+import { address, createSolanaRpc } from '@solana/kit';
+
+const ario = ARIO.init({
+  backend: 'solana',
+  rpc: createSolanaRpc('https://api.devnet.solana.com'),
+  coreProgramId: address('83CQLP848zzCgnZ4LTq87g6hvxTooNLX7YXXkUUGv5ig'),
+  garProgramId: address('AF8QAEaR4hzsqeUDwEdeTXMYtdyFegTENBdnJro6WVLR'),
+  arnsProgramId: address('2HgSCKYjcapJPdHRKqkLrGXm7kvBmCP45ZyhWEm87oM1'),
+  antProgramId: address('8ZMuXhiK7DorjPUg8RB1rzu7CvsABMk38WDJRbM62y2C'),
+});
 
 // Example: Network-first with static fallback
 const gatewayProvider = new CompositeGatewaysProvider({
   providers: [
     // Try fetching from AR.IO network first
     new NetworkGatewaysProvider({
-      ario: ARIO.mainnet(),
+      ario,
       sortBy: 'operatorStake',
       limit: 10,
     }),
@@ -325,6 +361,16 @@ import {
   NetworkGatewaysProvider,
 } from '@ar.io/wayfinder-core';
 import { ARIO } from '@ar.io/sdk';
+import { address, createSolanaRpc } from '@solana/kit';
+
+const ario = ARIO.init({
+  backend: 'solana',
+  rpc: createSolanaRpc('https://api.devnet.solana.com'),
+  coreProgramId: address('83CQLP848zzCgnZ4LTq87g6hvxTooNLX7YXXkUUGv5ig'),
+  garProgramId: address('AF8QAEaR4hzsqeUDwEdeTXMYtdyFegTENBdnJro6WVLR'),
+  arnsProgramId: address('2HgSCKYjcapJPdHRKqkLrGXm7kvBmCP45ZyhWEm87oM1'),
+  antProgramId: address('8ZMuXhiK7DorjPUg8RB1rzu7CvsABMk38WDJRbM62y2C'),
+});
 
 // Example 1: Performance-first with resilience fallback
 const performanceWayfinder = createWayfinderClient({
@@ -334,7 +380,7 @@ const performanceWayfinder = createWayfinderClient({
       new FastestPingRoutingStrategy({
         timeoutMs: 500,
         gatewaysProvider: new NetworkGatewaysProvider({
-          ario: ARIO.mainnet(),
+          ario,
           sortBy: 'operatorStake',
           limit: 10,
         }),
@@ -342,7 +388,7 @@ const performanceWayfinder = createWayfinderClient({
       // Fallback to random selection (guaranteed to work if gateways exist)
       new RandomRoutingStrategy({
         gatewaysProvider: new NetworkGatewaysProvider({
-          ario: ARIO.mainnet(),
+          ario,
           sortBy: 'operatorStake', 
           limit: 20, // Use more gateways for fallback
         }),
@@ -363,7 +409,7 @@ const preferredWayfinder = createWayfinderClient({
       new FastestPingRoutingStrategy({
         timeoutMs: 1000,
         gatewaysProvider: new NetworkGatewaysProvider({
-          ario: ARIO.mainnet(),
+          ario,
           sortBy: 'operatorStake',
           limit: 5, // Only top 5 gateways
         }),
@@ -371,7 +417,7 @@ const preferredWayfinder = createWayfinderClient({
       // Final fallback: any random gateway from a larger pool
       new RandomRoutingStrategy({
         gatewaysProvider: new NetworkGatewaysProvider({
-          ario: ARIO.mainnet(),
+          ario,
           limit: 50, // Larger pool for maximum availability
         }),
       }),


### PR DESCRIPTION
## Summary

wayfinder-core itself is **chain-agnostic** — it consumes only the `AoARIORead` type and delegates ARIO instance construction to the caller. But the published README only showed `ARIO.mainnet()` (the AO-era AR.IO mainnet) examples, which is misleading in the post-Solana-migration ecosystem.

## What changed

The four example blocks now use SDK 4.x Solana syntax:

```ts
const ario = ARIO.init({
  backend: 'solana',
  rpc: createSolanaRpc('https://api.devnet.solana.com'),
  coreProgramId: address('83CQLP848zzCgnZ4LTq87g6hvxTooNLX7YXXkUUGv5ig'),
  garProgramId: address('AF8QAEaR4hzsqeUDwEdeTXMYtdyFegTENBdnJro6WVLR'),
  arnsProgramId: address('2HgSCKYjcapJPdHRKqkLrGXm7kvBmCP45ZyhWEm87oM1'),
  antProgramId: address('8ZMuXhiK7DorjPUg8RB1rzu7CvsABMk38WDJRbM62y2C'),
});
```

The first example carries a comment explaining how to switch to mainnet (drop the program-ID overrides; the SDK ships mainnet defaults) once AR.IO Solana mainnet deploys, and reaffirms that wayfinder-core is chain-agnostic.

### Sections updated

- Getting Started → "Using with AR.IO Network"
- NetworkGatewaysProvider reference
- CompositeGatewaysProvider example
- CompositeRoutingStrategy examples 1 + 2

## Test plan

- [x] `npm run build -w @ar.io/wayfinder-core` still passes
- [x] Final grep for `ARIO.mainnet()` in `packages/wayfinder-core/README.md` returns no matches
- [ ] Manual readability check on the rendered README (markdown only, no executable verification)

Docs-only — no code changes. wayfinder-core's only SDK touchpoint (`network.ts:17 import type { AoARIORead }`) already type-checked against SDK 4.x in commit 991e450.

🤖 Generated with [Claude Code](https://claude.com/claude-code)