### PR TITLE
fix(core)!: remove hardcoded telemetry API key

### DIFF
--- a/.changeset/remove-default-telemetry-api-key.md
+++ b/.changeset/remove-default-telemetry-api-key.md
@@ -1,0 +1,39 @@
+---
+"@ar.io/wayfinder-core": major
+---
+
+**Breaking:** remove the default telemetry API key.
+
+`initTelemetry` previously fell back to an API key bundled in the published
+package when `telemetrySettings.apiKey` was not supplied. That key has been
+revoked. Telemetry is opt-in and disabled by default, so installs that never
+set `telemetrySettings.enabled: true` are unaffected.
+
+- `telemetrySettings.apiKey` no longer has a default value.
+- When `enabled` is `true` and `exporterUrl` targets Honeycomb, `apiKey` is now
+  required and `initTelemetry` throws if it is missing. Because `initTelemetry`
+  runs from the `Wayfinder` constructor, this surfaces at construction time.
+- Exporters pointed at a non-Honeycomb host are unaffected and may omit
+  `apiKey`; the `x-honeycomb-*` headers are only sent when a key is present.
+
+To keep exporting traces, supply your own key:
+
+```ts
+new Wayfinder({
+  telemetrySettings: {
+    enabled: true,
+    apiKey: process.env.HONEYCOMB_API_KEY,
+  },
+});
+```
+
+Or send them to a collector you operate, which needs no key:
+
+```ts
+new Wayfinder({
+  telemetrySettings: {
+    enabled: true,
+    exporterUrl: 'https://otel.example.com/v1/traces',
+  },
+});
+```

--- a/.changeset/remove-extension-telemetry-toggle.md
+++ b/.changeset/remove-extension-telemetry-toggle.md
@@ -1,0 +1,23 @@
+---
+"@ar.io/wayfinder-extension": minor
+---
+
+Remove the Anonymous Telemetry setting.
+
+`wayfinder-core` no longer provides a default telemetry API key, and a
+client-side extension has nowhere to keep one — any key it shipped would be
+readable by anyone who unpacked the bundle. Rather than ship a credential, the
+toggle is removed and the extension no longer initializes telemetry at all.
+
+- Dropped the telemetry toggle from the settings page, along with its change
+  handler, load path, and stored `telemetryEnabled` default.
+- `routing.ts` no longer passes `telemetrySettings` when constructing
+  `Wayfinder`. This also avoids the constructor throw that core now raises when
+  telemetry is enabled without an API key — which, because the constructor sits
+  on the `ar://` routing path, would have broken URL resolution outright for
+  anyone who had the toggle switched on.
+- Existing installs have their orphaned `telemetryEnabled` key removed on
+  startup by `migrateStorageFromTelemetryEra()`.
+
+No user action is required. Routing, verification, and gateway selection are
+unaffected.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "format:fix": "biome format --write",
     "format:check": "biome format",
     "verify": "tsx scripts/verify.ts",
+    "typecheck:scripts": "tsc --noEmit -p scripts/tsconfig.json",
     "prepare": "husky"
   },
   "repository": {

--- a/packages/wayfinder-core/src/client.test.ts
+++ b/packages/wayfinder-core/src/client.test.ts
@@ -130,4 +130,30 @@ describe('createWayfinderClient', () => {
 
     assert.strictEqual(wayfinder.telemetrySettings.enabled, true);
   });
+
+  it('should refuse to send an api key over plaintext http', () => {
+    assert.throws(
+      () =>
+        createWayfinderClient({
+          telemetrySettings: {
+            enabled: true,
+            apiKey: 'test-api-key',
+            exporterUrl: 'http://otel.example.com/v1/traces',
+          },
+        }),
+      /must use https when telemetrySettings\.apiKey is set/,
+    );
+  });
+
+  it('should allow an api key over http for a loopback collector', () => {
+    const wayfinder = createWayfinderClient({
+      telemetrySettings: {
+        enabled: true,
+        apiKey: 'test-api-key',
+        exporterUrl: 'http://localhost:4318/v1/traces',
+      },
+    });
+
+    assert.strictEqual(wayfinder.telemetrySettings.enabled, true);
+  });
 });

--- a/packages/wayfinder-core/src/client.test.ts
+++ b/packages/wayfinder-core/src/client.test.ts
@@ -90,10 +90,44 @@ describe('createWayfinderClient', () => {
       telemetrySettings: {
         enabled: true,
         sampleRate: 0.5,
+        apiKey: 'test-api-key',
       },
     });
 
     assert.strictEqual(wayfinder.telemetrySettings.enabled, true);
     assert.strictEqual(wayfinder.telemetrySettings.sampleRate, 0.5);
+  });
+
+  it('should throw when telemetry is enabled for Honeycomb without an api key', () => {
+    assert.throws(
+      () =>
+        createWayfinderClient({
+          telemetrySettings: {
+            enabled: true,
+          },
+        }),
+      /telemetrySettings\.apiKey is required/,
+    );
+  });
+
+  it('should not require an api key when telemetry is disabled', () => {
+    const wayfinder = createWayfinderClient({
+      telemetrySettings: {
+        enabled: false,
+      },
+    });
+
+    assert.strictEqual(wayfinder.telemetrySettings.enabled, false);
+  });
+
+  it('should not require an api key for a non-Honeycomb exporter', () => {
+    const wayfinder = createWayfinderClient({
+      telemetrySettings: {
+        enabled: true,
+        exporterUrl: 'https://otel.example.com/v1/traces',
+      },
+    });
+
+    assert.strictEqual(wayfinder.telemetrySettings.enabled, true);
   });
 });

--- a/packages/wayfinder-core/src/telemetry.ts
+++ b/packages/wayfinder-core/src/telemetry.ts
@@ -57,11 +57,25 @@ if (isBrowser()) {
   loadZonePolyfill();
 }
 
+const HONEYCOMB_EXPORTER_URL = 'https://api.honeycomb.io/v1/traces';
+
+// Honeycomb requires an API key on every OTLP request, but a self-hosted
+// collector may not, so the key is only mandatory when traces are actually
+// bound for Honeycomb (api.honeycomb.io, api.eu1.honeycomb.io, ...).
+const isHoneycombExporterUrl = (url: string): boolean => {
+  try {
+    const { hostname } = new URL(url);
+    return hostname === 'honeycomb.io' || hostname.endsWith('.honeycomb.io');
+  } catch {
+    return false;
+  }
+};
+
 export const initTelemetry = ({
   enabled = false,
   sampleRate = 0.1, // 10% sample rate by default
-  exporterUrl = 'https://api.honeycomb.io/v1/traces',
-  apiKey = 'c8gU8dHlu6V7e5k2Gn9LaG', // intentionally left here - if it gets abused we'll disable it
+  exporterUrl = HONEYCOMB_EXPORTER_URL,
+  apiKey,
   clientName,
   clientVersion,
 }: TelemetrySettings):
@@ -75,6 +89,16 @@ export const initTelemetry = ({
   | undefined => {
   if (enabled === false) return undefined;
 
+  // validated before the cached-provider check so the failure is deterministic
+  // regardless of whether this is the first call
+  if (!apiKey && isHoneycombExporterUrl(exporterUrl)) {
+    throw new Error(
+      'telemetrySettings.apiKey is required when telemetry is enabled and traces are exported to Honeycomb. ' +
+        'wayfinder-core no longer provides a default API key. Either set telemetrySettings.apiKey to a ' +
+        'Honeycomb ingest key you control, or point telemetrySettings.exporterUrl at your own OTLP collector.',
+    );
+  }
+
   // if the tracer provider and tracer are already initialized, return the tracer
   if (tracerProvider) {
     return {
@@ -87,10 +111,13 @@ export const initTelemetry = ({
 
   const exporter = new OTLPTraceExporter({
     url: exporterUrl,
-    headers: {
-      'x-honeycomb-team': apiKey,
-      'x-honeycomb-dataset': 'wayfinder-core',
-    },
+    // collectors other than Honeycomb may not need (or accept) an API key
+    headers: apiKey
+      ? {
+          'x-honeycomb-team': apiKey,
+          'x-honeycomb-dataset': 'wayfinder-core',
+        }
+      : {},
   });
 
   const sampler = new TraceIdRatioBasedSampler(sampleRate);

--- a/packages/wayfinder-core/src/telemetry.ts
+++ b/packages/wayfinder-core/src/telemetry.ts
@@ -62,10 +62,29 @@ const HONEYCOMB_EXPORTER_URL = 'https://api.honeycomb.io/v1/traces';
 // Honeycomb requires an API key on every OTLP request, but a self-hosted
 // collector may not, so the key is only mandatory when traces are actually
 // bound for Honeycomb (api.honeycomb.io, api.eu1.honeycomb.io, ...).
+// Honeycomb only serves https, so a plaintext URL is never really Honeycomb --
+// treating it as such would demand a key we then could not transmit safely.
 const isHoneycombExporterUrl = (url: string): boolean => {
   try {
-    const { hostname } = new URL(url);
+    const { protocol, hostname } = new URL(url);
+    if (protocol !== 'https:') return false;
     return hostname === 'honeycomb.io' || hostname.endsWith('.honeycomb.io');
+  } catch {
+    return false;
+  }
+};
+
+// An API key is a credential and must never travel in plaintext. Loopback is
+// exempt so a collector running locally during development still works.
+const isSecureExporterUrl = (url: string): boolean => {
+  try {
+    const { protocol, hostname } = new URL(url);
+    if (protocol === 'https:') return true;
+    return (
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1' ||
+      hostname === '[::1]'
+    );
   } catch {
     return false;
   }
@@ -91,6 +110,14 @@ export const initTelemetry = ({
 
   // validated before the cached-provider check so the failure is deterministic
   // regardless of whether this is the first call
+  if (apiKey && !isSecureExporterUrl(exporterUrl)) {
+    throw new Error(
+      'telemetrySettings.exporterUrl must use https when telemetrySettings.apiKey is set. ' +
+        'Sending an API key over plaintext would expose it. Use an https endpoint, or a ' +
+        'loopback address (localhost, 127.0.0.1) for a local collector.',
+    );
+  }
+
   if (!apiKey && isHoneycombExporterUrl(exporterUrl)) {
     throw new Error(
       'telemetrySettings.apiKey is required when telemetry is enabled and traces are exported to Honeycomb. ' +

--- a/packages/wayfinder-core/src/types.ts
+++ b/packages/wayfinder-core/src/types.ts
@@ -293,9 +293,16 @@ export interface TelemetrySettings {
   enabled: boolean;
   /** Sampling ratio between 0 and 1 */
   sampleRate?: number;
-  /** Honeycomb API key */
+  /**
+   * API key for the OTLP exporter, sent as the `x-honeycomb-team` header.
+   *
+   * Required when `enabled` is true and `exporterUrl` targets Honeycomb;
+   * `initTelemetry` throws otherwise. wayfinder-core does not provide a
+   * default — supply your own key, or point `exporterUrl` at a collector
+   * that does not require one.
+   */
   apiKey?: string;
-  /** Optional custom OTLP exporter URL */
+  /** Optional custom OTLP exporter URL. Defaults to Honeycomb's US endpoint. */
   exporterUrl?: string;
   /** Client name (e.g. "wayfinder-extension") */
   clientName?: string;

--- a/packages/wayfinder-extension/CLAUDE.md
+++ b/packages/wayfinder-extension/CLAUDE.md
@@ -102,4 +102,7 @@ Background script accepts these message types:
 - Background script restarts can lose state (use chrome.storage)
 - WebRequest API needed for performance tracking
 - Some gateways may have CORS issues with HEAD requests
-- Telemetry may fail due to AsyncLocalStorage browser compatibility
+- The extension does not initialize telemetry. `wayfinder-core` requires a
+  `telemetrySettings.apiKey` when telemetry is enabled, and a client-side
+  extension has nowhere to keep one — so the toggle was removed rather than
+  shipping a bundled key.

--- a/packages/wayfinder-extension/CLAUDE.md
+++ b/packages/wayfinder-extension/CLAUDE.md
@@ -103,6 +103,9 @@ Background script accepts these message types:
 - WebRequest API needed for performance tracking
 - Some gateways may have CORS issues with HEAD requests
 - The extension does not initialize telemetry. `wayfinder-core` requires a
-  `telemetrySettings.apiKey` when telemetry is enabled, and a client-side
-  extension has nowhere to keep one — so the toggle was removed rather than
-  shipping a bundled key.
+  `telemetrySettings.apiKey` when telemetry is enabled *and* the exporter
+  targets Honeycomb, and a client-side extension has nowhere to keep a
+  credential — so the toggle was removed rather than shipping a bundled key.
+  Telemetry could be restored without one by pointing
+  `telemetrySettings.exporterUrl` at an OTLP collector we operate, which holds
+  the Honeycomb key server-side.

--- a/packages/wayfinder-extension/assets/css/settings.css
+++ b/packages/wayfinder-extension/assets/css/settings.css
@@ -993,31 +993,6 @@ body {
   border-top: 1px solid rgba(212, 198, 255, 0.1);
 }
 
-/* Telemetry Info */
-.telemetry-info {
-  margin-top: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.telemetry-info .info-item {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-family: var(--font-family-body, "Plus Jakarta Sans", sans-serif);
-  font-weight: 400;
-  font-size: 12px;
-  line-height: 1.4;
-  color: var(--colors-text-textMid, #9b93b4);
-}
-
-.telemetry-info .info-item svg {
-  width: 14px;
-  height: 14px;
-  flex-shrink: 0;
-}
-
 /* Verification Strategy Section */
 .verification-strategy-section {
   margin-top: 16px;

--- a/packages/wayfinder-extension/src/background.ts
+++ b/packages/wayfinder-extension/src/background.ts
@@ -356,6 +356,26 @@ async function migrateStaleDevnetProgramIds(): Promise<void> {
   ]);
 }
 
+/**
+ * Drop the `telemetryEnabled` key left behind by installs that predate the
+ * removal of the telemetry toggle. The extension no longer initializes
+ * telemetry at all, so the stored preference has no reader.
+ * No-op once removed, and on fresh installs.
+ */
+async function migrateStorageFromTelemetryEra(): Promise<void> {
+  const { telemetryEnabled } = await chrome.storage.local.get([
+    'telemetryEnabled',
+  ]);
+
+  if (telemetryEnabled === undefined) return;
+
+  logger.info(
+    '[migration] Removing orphaned telemetryEnabled preference; the telemetry toggle no longer exists.',
+  );
+
+  await chrome.storage.local.remove(['telemetryEnabled']);
+}
+
 // Solana-backed AR.IO read instance; initialized at startup inside the
 // async IIFE below after storage defaults are applied.
 let arIO: ARIORead | undefined;
@@ -364,6 +384,7 @@ let arIO: ARIORead | undefined;
 (async () => {
   await migrateStorageFromAOEra();
   await migrateStaleDevnetProgramIds();
+  await migrateStorageFromTelemetryEra();
 
   const { dailyStats, localGatewayAddressRegistry } =
     await chrome.storage.local.get([

--- a/packages/wayfinder-extension/src/config/defaults.ts
+++ b/packages/wayfinder-extension/src/config/defaults.ts
@@ -77,9 +77,6 @@ export const WAYFINDER_DEFAULTS = {
   gatewayCacheTTL: 3600, // 1 hour in seconds
   gatewaySortBy: 'totalDelegatedStake',
   gatewaySortOrder: 'desc',
-
-  // Telemetry Configuration (opt-in, default disabled)
-  telemetryEnabled: false,
 } as const;
 
 /**

--- a/packages/wayfinder-extension/src/routing.ts
+++ b/packages/wayfinder-extension/src/routing.ts
@@ -37,7 +37,6 @@ import {
 } from './constants';
 import { fetchEnsArweaveTxId } from './ens';
 import { logger } from './utils/logger';
-import { getExtensionVersion } from './utils/version';
 
 /**
  * Global Wayfinder instance for the extension with thread-safe initialization
@@ -83,14 +82,12 @@ async function createWayfinderInstance(): Promise<Wayfinder> {
     staticGateway = WAYFINDER_DEFAULTS.staticGateway,
     gatewaySortBy = WAYFINDER_DEFAULTS.gatewaySortBy,
     gatewaySortOrder = WAYFINDER_DEFAULTS.gatewaySortOrder,
-    telemetryEnabled = WAYFINDER_DEFAULTS.telemetryEnabled,
   } = await chrome.storage.local.get([
     'routingMethod',
     'staticGateway',
     'gatewayCacheTTL',
     'gatewaySortBy',
     'gatewaySortOrder',
-    'telemetryEnabled',
   ]);
 
   // Create the base gateway provider with configurable sorting
@@ -169,19 +166,13 @@ async function createWayfinderInstance(): Promise<Wayfinder> {
         },
       },
     },
-    verificationSettings: {
-      strategy: new RemoteVerificationStrategy(),
-    },
     /**
      * NOTE: because we don't get access to the first bytes of the response, we can't verify the data directly here.
      *
      * Instead, we set up a chrome listener for response headers, and check the 'x-ar-io-verified' header using the RemoteVerificationStrategy provided by Wayfinder Core.
      */
-    telemetrySettings: {
-      enabled: telemetryEnabled,
-      sampleRate: 1, // send all ar:// requests
-      clientName: 'wayfinder-extension',
-      clientVersion: await getExtensionVersion(),
+    verificationSettings: {
+      strategy: new RemoteVerificationStrategy(),
     },
   });
 

--- a/packages/wayfinder-extension/src/settings.html
+++ b/packages/wayfinder-extension/src/settings.html
@@ -332,37 +332,6 @@
                 <p>When enabled, displays brief notifications when content has been remotely verified by AR.IO gateways. Helps you identify verified content while browsing.</p>
               </div>
             </div>
-
-            <!-- Telemetry -->
-            <div class="advanced-option">
-              <div class="option-header">
-                <div class="option-info">
-                  <h3>Anonymous Telemetry</h3>
-                  <p>Help improve Wayfinder by sharing anonymous usage data</p>
-                </div>
-                <label class="toggle-switch">
-                  <input type="checkbox" id="telemetryToggle">
-                  <span class="toggle-slider"></span>
-                </label>
-              </div>
-              <div class="option-description" id="telemetryDetails">
-                <p>When enabled, 10% of routing requests will include anonymous performance metrics to help improve gateway selection algorithms. No personal data or browsing history is collected.</p>
-                <div class="telemetry-info">
-                  <div class="info-item">
-                    <svg width="14" height="14" viewBox="0 0 36 36" fill="none">
-                      <path d="M27 13.5L15 25.5L9 19.5" stroke="var(--colors-success-successHigh)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                    </svg>
-                    <span>Completely anonymous</span>
-                  </div>
-                  <div class="info-item">
-                    <svg width="14" height="14" viewBox="0 0 36 36" fill="none">
-                      <path d="M27 13.5L15 25.5L9 19.5" stroke="var(--colors-success-successHigh)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                    </svg>
-                    <span>Improves routing performance</span>
-                  </div>
-                </div>
-              </div>
-            </div>
           </div>
         </section>
 

--- a/packages/wayfinder-extension/src/settings.ts
+++ b/packages/wayfinder-extension/src/settings.ts
@@ -187,11 +187,6 @@ function setupEventHandlers() {
   document
     .getElementById('gatewayCacheTTL')
     ?.addEventListener('input', handleGatewayCacheTTLChange);
-
-  // Telemetry toggle
-  document
-    .getElementById('telemetryToggle')
-    ?.addEventListener('change', handleTelemetryToggle);
 }
 
 function setupExpandableSections() {
@@ -248,7 +243,6 @@ async function loadCurrentSettings() {
       'gatewaySortOrder',
       'gatewayCacheTTL',
       'advancedSettingsExpanded',
-      'telemetryEnabled',
       'showVerificationToasts',
     ]);
 
@@ -377,20 +371,6 @@ async function loadCurrentSettings() {
     ) as HTMLInputElement;
     if (gatewayCacheTTLValueEl) {
       gatewayCacheTTLValueEl.textContent = gatewayCacheTTL;
-    }
-
-    // Load telemetry settings
-    const telemetryEnabled = settings.telemetryEnabled || false;
-    const telemetryToggle = document.getElementById(
-      'telemetryToggle',
-    ) as HTMLInputElement;
-    if (telemetryToggle) {
-      telemetryToggle.checked = telemetryEnabled;
-      // Update details visibility
-      const telemetryDetails = document.getElementById('telemetryDetails');
-      if (telemetryDetails) {
-        telemetryDetails.style.display = telemetryEnabled ? 'block' : 'none';
-      }
     }
   } catch (error) {
     console.error('Error loading settings:', error);
@@ -1167,29 +1147,6 @@ async function handleGatewayCacheTTLChange(event: any) {
 }
 
 // Removed: Verified Browsing handlers - verification features removed
-
-// Telemetry handler
-async function handleTelemetryToggle(event: any) {
-  const enabled = event.target.checked;
-
-  await chrome.storage.local.set({ telemetryEnabled: enabled });
-
-  // Reset wayfinder to apply telemetry changes
-  chrome.runtime.sendMessage({ message: 'resetWayfinder' });
-
-  // Update telemetry details visibility
-  const details = document.getElementById('telemetryDetails');
-  if (details) {
-    details.style.display = enabled ? 'block' : 'none';
-  }
-
-  showToast(
-    enabled
-      ? 'Telemetry enabled - Reload extension to apply changes'
-      : 'Telemetry disabled - Reload extension to apply changes',
-    'info',
-  );
-}
 
 // Data Management Functions
 async function clearAllCache() {

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,16 @@
     "jsx": "preserve",
     "sourceMap": true
   },
-  "include": ["packages/**/*.ts", "packages/**/*.tsx", "scripts/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  // scripts/ is deliberately excluded: scripts/x402-fetch.ts imports viem and
+  // the x402 wallet stack, which pulls ~1700 extra declaration files into this
+  // project. Those scripts are standalone examples and are typechecked under
+  // experimental/wayfinder-x402-fetch instead.
+  "include": ["packages/**/*.ts", "packages/**/*.tsx"],
+  "exclude": ["**/node_modules", "**/dist"],
+  // Watching node_modules registers ~1600 "file location affecting resolution"
+  // watchers (mostly viem's per-chain .d.ts files, installed in triplicate),
+  // which makes any filesystem activity invalidate resolution across projects.
+  "watchOptions": {
+    "excludeDirectories": ["**/node_modules", "**/dist"]
+  }
 }


### PR DESCRIPTION
## Summary

`initTelemetry` fell back to an API key bundled in the published package when `telemetrySettings.apiKey` was not supplied. That key has been revoked. This removes the default, requires callers to supply their own, and removes the extension's telemetry toggle since a client-side extension has nowhere to keep a credential.

Telemetry is opt-in and disabled by default at every layer, so installs that never set `telemetrySettings.enabled: true` are unaffected.

## `@ar.io/wayfinder-core` (major)

- `telemetrySettings.apiKey` no longer has a default value.
- When telemetry is enabled and `exporterUrl` targets Honeycomb, `apiKey` is required and `initTelemetry` throws. Since `initTelemetry` runs from the `Wayfinder` constructor, this surfaces at construction time.
- Exporters pointed at any other host may omit `apiKey`; the `x-honeycomb-*` headers are only sent when a key is present, so a self-hosted collector no longer receives an empty `x-honeycomb-team`.
- Honeycomb is detected by hostname over `https` rather than exact URL match, so regional endpoints (`api.eu1.honeycomb.io`) are covered rather than silently 401ing.
- An `apiKey` supplied with a non-https exporter URL is rejected outright, so a credential can never be sent in cleartext. Loopback addresses are exempt so local collectors still work.
- Validation runs before the cached-provider early return, so the failure is deterministic regardless of initialization order.

**Breaking:** `telemetrySettings.apiKey` is required when telemetry is enabled and traces go to Honeycomb.

## `@ar.io/wayfinder-extension` (minor)

The extension passed `telemetrySettings` with no `apiKey`, relying entirely on the core default. Under the new behaviour that throws — and because the `Wayfinder` constructor sits on the `ar://` routing path, it would have broken URL resolution outright for anyone who had the toggle switched on, not merely stopped traces.

Rather than ship a bundled credential, the feature is removed:

- Telemetry toggle removed from the settings page, along with its change handler, load path, and stored default.
- `routing.ts` no longer passes `telemetrySettings`.
- Orphaned `telemetryEnabled` storage key cleared on startup by `migrateStorageFromTelemetryEra()`, following the existing migration pattern.
- Dead `.telemetry-info` CSS removed (`.info-item` is unused elsewhere).

Routing, verification, and gateway selection are unaffected. No user action required.

Telemetry could be restored later without any client-side credential by pointing `exporterUrl` at an OTLP collector we operate.

## Tooling

The root `tsconfig.json` is editor-only — builds run per workspace — but it was the largest TS program in the repo and caused tsserver to cycle between project initializations:

- `scripts/` dropped from `include`. `scripts/x402-fetch.ts` imports viem and the x402 wallet stack, pulling ~1700 extra declaration files in. Program goes from 3023 to 1284 files, 511MB to 310MB. `scripts/tsconfig.json` plus `npm run typecheck:scripts` keeps those files checked without pulling the declarations back in.
- `watchOptions.excludeDirectories` added. tsserver was registering ~1600 "file location affecting resolution" watchers under `node_modules`, mostly viem's per-chain `.d.ts` files (installed in triplicate), so any build or install invalidated resolution across every project.
- `exclude` widened from `["node_modules", "dist"]` to `["**/node_modules", "**/dist"]` — the unprefixed form only matched the repo root, so per-package `dist` output was being pulled in as root files.
- `typescript.tsserver.watchOptions` added to `.vscode/settings.json`. The package tsconfigs are standalone — only `experimental/wayfinder-cli` extends the root — so `watchOptions` in any single tsconfig covers only that project. The editor-level setting applies to every project the server loads. It cannot cover the recursive watchers Node's resolution walk-up places on ancestor directories above the repo, since `excludeDirectories` resolves relative to the project root.

## Testing

- `wayfinder-core`: 135/135 passing, including six new cases covering the throw, the disabled path, the non-Honeycomb exporter path, and the plaintext-credential rejection.
- `lint:check` clean for `wayfinder-core` and `wayfinder-extension`; `typecheck:scripts` clean.
- Extension builds via Vite; verified the removed key is absent from `dist/`.

## Follow-ups (not in this PR)

- Startup migrations in `background.ts` are unguarded — pre-existing for all three, worth hardening as its own change (see review thread).
- The OTel exporter and `zone.js` are still bundled into the extension because core imports `telemetry.ts` unconditionally — inert, but tree-shakeable dead weight.
- `packages/wayfinder-core/src/version.ts` is a patch behind `package.json` on `main` (not on `alpha`), so spans there carry a stale version attribute.
- Consider project references to remove the root/per-package program overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
